### PR TITLE
Within Distance Query

### DIFF
--- a/src/main/java/org/neo4j/gis/spatial/AbstractSearch.java
+++ b/src/main/java/org/neo4j/gis/spatial/AbstractSearch.java
@@ -61,6 +61,13 @@ public abstract class AbstractSearch implements Search {
 		results.add(new SpatialDatabaseRecord(layer, geomNode, geom));
 	}
 	
+    protected void add(Node geomNode, Geometry geom,double distanceInKm) {
+        SpatialDatabaseRecord result = new SpatialDatabaseRecord( layer,
+                geomNode, geom );
+        result.setProperty( "distanceInKm", distanceInKm );
+        results.add( result );
+    }
+	
 	protected Envelope getEnvelope(Node geomNode) {
 		return layer.getGeometryEncoder().decodeEnvelope(geomNode);	
 	}

--- a/src/main/java/org/neo4j/gis/spatial/indexprovider/LayerNodeIndex.java
+++ b/src/main/java/org/neo4j/gis/spatial/indexprovider/LayerNodeIndex.java
@@ -80,7 +80,8 @@ public class LayerNodeIndex implements Index<Node>
         double lon = (Double) geometry.getProperty( LON_PROPERTY_KEY );
         double lat = (Double) geometry.getProperty( LAT_PROPERTY_KEY );
         layer.add( layer.getGeometryFactory().createPoint(
-                new Coordinate( lon, lat ) ) );
+        new Coordinate( lon, lat ) ), new String[] { "id" },
+        new Object[] { geometry.getId() } );
 
     }
 

--- a/src/main/java/org/neo4j/gis/spatial/query/SearchPointsWithinOrthodromicDistance.java
+++ b/src/main/java/org/neo4j/gis/spatial/query/SearchPointsWithinOrthodromicDistance.java
@@ -65,7 +65,7 @@ public class SearchPointsWithinOrthodromicDistance extends AbstractSearch {
 				Math.cos(Math.toRadians(refPoint.getY())) * Math.cos(Math.toRadians(point.getY())) * Math.cos(Math.toRadians(point.getX()) - Math.toRadians(refPoint.getX()))) * earthRadiusInKm;
 		
 		if (distanceInKm < maxDistanceInKm) {
-			add(geomNode, geometry);
+			add(geomNode, geometry, distanceInKm);
 		}
 	}
 

--- a/src/test/java/org/neo4j/gis/spatial/IndexProviderTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/IndexProviderTest.java
@@ -81,17 +81,21 @@ public class IndexProviderTest
     public void testWithinDistanceIndex() {
         LayerNodeIndex index = new LayerNodeIndex( "layer1", db, new HashMap<String, String>() );
         Transaction tx = db.beginTx();
-        Node n1 = db.createNode();
-        n1.setProperty( "lat", (double)56.2 );
-        n1.setProperty( "lon", (double)15.3 );
-        index.add( n1, "dummy", "value" );
+        Node batman = db.createNode();
+        batman.setProperty( "lat", (double) 37.88 );
+        batman.setProperty( "lon", (double) 41.14 );
+        batman.setProperty( "name", "batman" );
+        index.add( batman, "dummy", "value" );
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put( LayerNodeIndex.POINT_PARAMETER,  new Double[] { 37.87, 41.13 } );
+        params.put( LayerNodeIndex.DISTANCE_IN_KM_PARAMETER, 2.0 );
+        IndexHits<Node> hits = index.query( LayerNodeIndex.WITHIN_DISTANCE_QUERY, params );
         tx.success();
         tx.finish();
-	   Map<String, Object> params = new HashMap<String, Object>();   
-	   params.put(LayerNodeIndex.POINT_PARAMETER, new Double[] { 56.21,15.31 });
-	   params.put(LayerNodeIndex.DISTANCE_IN_KM_PARAMETER, 2.0);
-	   IndexHits<Node> hits = index.query( LayerNodeIndex.WITHIN_DISTANCE_QUERY, params );
-        assertTrue(hits.hasNext());
+        Node spatialRecord = hits.getSingle();
+        assertTrue( spatialRecord.getProperty( "distanceInKm" ).equals( 1.416623647558699 ) );
+        Node node = db.getNodeById( (Long) spatialRecord.getProperty( "id" ) );
+        assertTrue( node.getProperty( "name" ).equals( "batman" ) );
         
         
     }


### PR DESCRIPTION
Hi, 
I have made a couple of changes to the LayerNodeIndex, please let me know what you think:
When adding a new SpatialDatabaseRecord in the LayerNodeIndex I have passed in the associated graph node id as a property.
I have added a Within Distance Query to the LayerNodeIndex which uses a SearchPointsWithinOrthodromicDistance.
When returning the results from SearchPointsWithinOrthodromicDistance I have set the calculated distanceInKm as a property in each returned SpatialDatabaseRecord. I'm not sure if this is the best method as it requires the query to be in a transaction.

Thanks,
Paddy
