### PR TITLE
adding dependency on commons-lang

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,11 @@ terms of the relevant Commercial Agreement.
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+        <groupId>commons-lang</groupId>
+        <artifactId>commons-lang</artifactId>
+        <version>2.4</version>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>


### PR DESCRIPTION
An issue came up on the mailing list: https://groups.google.com/forum/#!topic/neo4j/fG1hmr34nU4

Not sure how it appeared, but the code uses commons-lang, so now has explicit dependency.
