### PR TITLE
remove build warnings due to missing version numbers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,9 @@
         <neo4j.version>2.0.0-M06</neo4j.version>
         <neo4j.java.version>1.7</neo4j.java.version>
         <neo4j.graphcollections.version>0.7.1-neo4j-2.0.0-SNAPSHOT</neo4j.graphcollections.version>
+        <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
+        <maven-gpg-plugin.version>1.4</maven-gpg-plugin.version>
+        <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
         <skinGroupId>org.neo4j.maven.skins</skinGroupId>
         <skinArtifactId>default-skin</skinArtifactId>
         <skinVersion>2</skinVersion>
@@ -34,6 +37,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>
@@ -42,6 +46,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
+                <version>${maven-gpg-plugin.version}</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -49,6 +54,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
+                <version>${maven-resources-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>copy-resources</id>


### PR DESCRIPTION
Dear all

I added some version numbers to get rid of the warnings when running the build.

Feel free to pull the version into the master.

Kind regards,

Christoph
