### PR TITLE
Fixing unnecessary writes into RTreeIndex node

### DIFF
--- a/src/main/java/org/neo4j/gis/spatial/rtree/RTreeIndex.java
+++ b/src/main/java/org/neo4j/gis/spatial/rtree/RTreeIndex.java
@@ -426,7 +426,12 @@ public class RTreeIndex implements SpatialIndexWriter {
 			SpatialIndexRecordCounter counter = new SpatialIndexRecordCounter();
 			visit(counter, getIndexRoot());
 			totalGeometryCount = counter.getResult();
-			countSaved = false;
+
+			Object savedGeometryCount = null;
+			if(getMetadataNode().hasProperty("totalGeometryCount")) {
+				savedGeometryCount = getMetadataNode().getProperty("totalGeometryCount");
+			}
+			countSaved = (savedGeometryCount != null && savedGeometryCount.equals(totalGeometryCount));
 		}
 	 	
 		if (!countSaved) {

--- a/src/main/java/org/neo4j/gis/spatial/rtree/RTreeIndex.java
+++ b/src/main/java/org/neo4j/gis/spatial/rtree/RTreeIndex.java
@@ -427,11 +427,8 @@ public class RTreeIndex implements SpatialIndexWriter {
 			visit(counter, getIndexRoot());
 			totalGeometryCount = counter.getResult();
 
-			Object savedGeometryCount = null;
-			if(getMetadataNode().hasProperty("totalGeometryCount")) {
-				savedGeometryCount = getMetadataNode().getProperty("totalGeometryCount");
-			}
-			countSaved = (savedGeometryCount != null && savedGeometryCount.equals(totalGeometryCount));
+			int savedGeometryCount = (int)getMetadataNode().getProperty("totalGeometryCount",0);
+			countSaved = savedGeometryCount == totalGeometryCount;
 		}
 	 	
 		if (!countSaved) {


### PR DESCRIPTION
- Checking whether the number of nodes has changed or not
- Saving only in case it has
- Prevents the thread to acquire a write lock unnecessarily improving the performance in concurrent reads.