### PR TITLE
Update to Neo4J 2.2.2, fix compile errors, tests are green

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <properties>
-        <neo4j.version>2.2.0</neo4j.version>
+        <neo4j.version>2.2.2</neo4j.version>
         <neo4j.java.version>1.7</neo4j.java.version>
         <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
         <maven-gpg-plugin.version>1.4</maven-gpg-plugin.version>
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-spatial</artifactId>
     <groupId>org.neo4j</groupId>
-    <version>0.14-neo4j-2.2.0</version>
+    <version>0.14-neo4j-2.2.2</version>
     <name>Neo4j - Spatial Components</name>
     <description>Spatial utilities and components for Neo4j</description>
     <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/src/main/java/org/neo4j/gis/spatial/indexprovider/SpatialIndexImplementation.java
+++ b/src/main/java/org/neo4j/gis/spatial/indexprovider/SpatialIndexImplementation.java
@@ -28,9 +28,9 @@ import java.util.Map;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.index.IndexCommandFactory;
 import org.neo4j.graphdb.index.LegacyIndexProviderTransaction;
+import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.api.LegacyIndex;
 import org.neo4j.kernel.impl.transaction.command.NeoCommandHandler;
-import org.neo4j.kernel.impl.util.ResourceIterators;
 
 public class SpatialIndexImplementation implements IndexImplementation {
 
@@ -86,6 +86,6 @@ public class SpatialIndexImplementation implements IndexImplementation {
     @Override
     public ResourceIterator<File> listStoreFiles() throws IOException {
 	    // this is a graph based index
-	    return ResourceIterators.EMPTY_ITERATOR;
+	    return IteratorUtil.emptyIterator();
     }
 }

--- a/src/main/java/org/neo4j/gis/spatial/indexprovider/SpatialRecordHits.java
+++ b/src/main/java/org/neo4j/gis/spatial/indexprovider/SpatialRecordHits.java
@@ -32,7 +32,6 @@ import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.index.IndexHits;
 import org.neo4j.helpers.collection.CatchingIteratorWrapper;
 import org.neo4j.helpers.collection.IteratorUtil;
-import org.neo4j.index.impl.lucene.IdToEntityIterator;
 
 /**
  * I've replaced the {@link SpatialRecordHits} class with this one, which is


### PR DESCRIPTION
This patch fixes #186 by removing two references to *.impl.* classes.
