### PR TITLE
Upgrade to 2.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <properties>
-        <neo4j.version>2.2.3</neo4j.version>
+        <neo4j.version>2.2.4</neo4j.version>
         <neo4j.java.version>1.7</neo4j.java.version>
         <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
         <maven-gpg-plugin.version>1.4</maven-gpg-plugin.version>
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-spatial</artifactId>
     <groupId>org.neo4j</groupId>
-    <version>0.14-neo4j-2.2.3</version>
+    <version>0.14-neo4j-2.2.4</version>
     <name>Neo4j - Spatial Components</name>
     <description>Spatial utilities and components for Neo4j</description>
     <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>
@@ -122,8 +122,11 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.13</version>
+                <version>2.18.1</version>
                 <configuration>
+                    <threadCount>1</threadCount>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
                     <argLine>-server -Xms512m -Xmx1024m</argLine>
                 </configuration>
             </plugin>
@@ -634,7 +637,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.11</version>
+                <version>2.18.1</version>
                 <configuration>
                     <argLine>-server -Xms512m -Xmx2G -XX:+UseConcMarkSweepGC</argLine>
                 </configuration>

--- a/src/test/java/org/neo4j/gis/spatial/Neo4jTestCase.java
+++ b/src/test/java/org/neo4j/gis/spatial/Neo4jTestCase.java
@@ -59,20 +59,24 @@ import org.neo4j.unsafe.batchinsert.BatchInserters;
 public abstract class Neo4jTestCase extends TestCase {
     public static final Map<String, String> NORMAL_CONFIG = new HashMap<String, String>();
     static {
-        NORMAL_CONFIG.put( GraphDatabaseSettings.nodestore_mapped_memory_size.name(), "50M" );
-        NORMAL_CONFIG.put( GraphDatabaseSettings.relationshipstore_mapped_memory_size.name(), "120M" );
-        NORMAL_CONFIG.put( GraphDatabaseSettings.nodestore_propertystore_mapped_memory_size.name(), "150M" );
-        NORMAL_CONFIG.put( GraphDatabaseSettings.strings_mapped_memory_size.name(), "200M" );
-        NORMAL_CONFIG.put( GraphDatabaseSettings.arrays_mapped_memory_size.name(), "0M" );
+        //NORMAL_CONFIG.put( GraphDatabaseSettings.nodestore_mapped_memory_size.name(), "50M" );
+        //NORMAL_CONFIG.put( GraphDatabaseSettings.relationshipstore_mapped_memory_size.name(), "120M" );
+        //NORMAL_CONFIG.put( GraphDatabaseSettings.nodestore_propertystore_mapped_memory_size.name(), "150M" );
+        //NORMAL_CONFIG.put( GraphDatabaseSettings.strings_mapped_memory_size.name(), "200M" );
+        //NORMAL_CONFIG.put( GraphDatabaseSettings.arrays_mapped_memory_size.name(), "0M" );
+	NORMAL_CONFIG.put( GraphDatabaseSettings.pagecache_memory.name(), "200M" );
+	NORMAL_CONFIG.put( GraphDatabaseSettings.batch_inserter_batch_size.name(), "2" );
         NORMAL_CONFIG.put( GraphDatabaseSettings.dump_configuration.name(), "false" );
     }
     protected static final Map<String, String> LARGE_CONFIG = new HashMap<String, String>();
     static {
-        LARGE_CONFIG.put( GraphDatabaseSettings.nodestore_mapped_memory_size.name(), "100M" );
-        LARGE_CONFIG.put( GraphDatabaseSettings.relationshipstore_mapped_memory_size.name(), "300M" );
-        LARGE_CONFIG.put( GraphDatabaseSettings.nodestore_propertystore_mapped_memory_size.name(), "400M" );
-        LARGE_CONFIG.put( GraphDatabaseSettings.strings_mapped_memory_size.name(), "800M" );
-        LARGE_CONFIG.put( GraphDatabaseSettings.arrays_mapped_memory_size.name(), "10M" );
+        //LARGE_CONFIG.put( GraphDatabaseSettings.nodestore_mapped_memory_size.name(), "100M" );
+        //LARGE_CONFIG.put( GraphDatabaseSettings.relationshipstore_mapped_memory_size.name(), "300M" );
+        //LARGE_CONFIG.put( GraphDatabaseSettings.nodestore_propertystore_mapped_memory_size.name(), "400M" );
+        //LARGE_CONFIG.put( GraphDatabaseSettings.strings_mapped_memory_size.name(), "800M" );
+        //LARGE_CONFIG.put( GraphDatabaseSettings.arrays_mapped_memory_size.name(), "10M" );
+	LARGE_CONFIG.put( GraphDatabaseSettings.pagecache_memory.name(), "100M" );
+	LARGE_CONFIG.put( GraphDatabaseSettings.batch_inserter_batch_size.name(), "2" );
         LARGE_CONFIG.put( GraphDatabaseSettings.dump_configuration.name(), "true" );
     }
     private static File basePath = new File("target/var");

--- a/src/test/java/org/neo4j/gis/spatial/TestsForDocs.java
+++ b/src/test/java/org/neo4j/gis/spatial/TestsForDocs.java
@@ -107,14 +107,16 @@ public class TestsForDocs extends Neo4jTestCase {
 	}
 
 	private void importMapOSM() throws Exception {
+		reActivateDatabase(false, true, false);
 		// START SNIPPET: importOsm
 		OSMImporter importer = new OSMImporter("map.osm");
 		importer.setCharset(Charset.forName("UTF-8"));
-		BatchInserter batchInserter = BatchInserters.inserter(databasePath);
+		BatchInserter batchInserter = getBatchInserter();
 		importer.importFile(batchInserter, "map.osm", false);
-		batchInserter.shutdown();
-
-		GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase(databasePath);
+		//batchInserter.shutdown();
+		//GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase(databasePath);
+		reActivateDatabase(false, false, false);
+		GraphDatabaseService db = graphDb();
 		importer.reIndex(db);
 		db.shutdown();
 		// END SNIPPET: importOsm
@@ -126,14 +128,17 @@ public class TestsForDocs extends Neo4jTestCase {
 	 * @throws Exception
 	 */
 	public void testImportOSM() throws Exception {
-		super.shutdownDatabase(true);
-		deleteDatabase(true);
+		//super.shutdownDatabase(true);
+		//deleteDatabase(true);
+		reActivateDatabase(true, true, false);
 
 		System.out.println("\n=== Simple test map.osm ===");
 		importMapOSM();
-
+		
 		// START SNIPPET: searchBBox
-		GraphDatabaseService database = new GraphDatabaseFactory().newEmbeddedDatabase(databasePath);
+		//GraphDatabaseService database = new GraphDatabaseFactory().newEmbeddedDatabase(databasePath);
+		reActivateDatabase(false, false, false);
+		GraphDatabaseService database = graphDb();
 		try {
 			SpatialDatabaseService spatialService = new SpatialDatabaseService(database);
 			Layer layer = spatialService.getLayer("map.osm");
@@ -158,13 +163,16 @@ public class TestsForDocs extends Neo4jTestCase {
 	}
 
 	public void testImportShapefile() throws Exception {
-		super.shutdownDatabase(true);
-		deleteDatabase(true);
+		//super.shutdownDatabase(true);
+		//deleteDatabase(true);
+		reActivateDatabase(true, true, false);
 
 		System.out.println("\n=== Test Import Shapefile ===");
 
 		// START SNIPPET: importShapefile
-		GraphDatabaseService database = new GraphDatabaseFactory().newEmbeddedDatabase(databasePath);
+		reActivateDatabase(false, false, false);
+		//GraphDatabaseService database = new GraphDatabaseFactory().newEmbeddedDatabase(databasePath);
+		GraphDatabaseService database = graphDb();
 		try {
 			ShapefileImporter importer = new ShapefileImporter(database);
 			importer.importFile("shp/highway.shp", "highway", Charset.forName("UTF-8"));
@@ -177,13 +185,15 @@ public class TestsForDocs extends Neo4jTestCase {
 	}
 
 	public void testExportShapefileFromOSM() throws Exception {
-		super.shutdownDatabase(true);
-		deleteDatabase(true);
+		//super.shutdownDatabase(true);
+		//deleteDatabase(true);
+		reActivateDatabase(true, true, false);
 
 		System.out.println("\n=== Test import map.osm, create DynamicLayer and export shapefile ===");
 		importMapOSM();
-
-		GraphDatabaseService database = new GraphDatabaseFactory().newEmbeddedDatabase(databasePath);
+		reActivateDatabase(false, false, false);
+		//GraphDatabaseService database = new GraphDatabaseFactory().newEmbeddedDatabase(databasePath);
+		GraphDatabaseService database = graphDb();
 		try {
 			// START SNIPPET: exportShapefileFromOSM
             SpatialDatabaseService spatialService = new SpatialDatabaseService(database);
@@ -201,13 +211,16 @@ public class TestsForDocs extends Neo4jTestCase {
 	}
 
 	public void testExportShapefileFromQuery() throws Exception {
-		super.shutdownDatabase(true);
-		deleteDatabase(true);
+		//super.shutdownDatabase(true);
+		//deleteDatabase(true);
+		reActivateDatabase(true, true, false);
 
 		System.out.println("\n=== Test import map.osm, create DynamicLayer and export shapefile ===");
 		importMapOSM();
 
-		GraphDatabaseService database = new GraphDatabaseFactory().newEmbeddedDatabase(databasePath);
+		reActivateDatabase(false, false, false);
+		//GraphDatabaseService database = new GraphDatabaseFactory().newEmbeddedDatabase(databasePath);
+		GraphDatabaseService database = graphDb();
 		try {
 			// START SNIPPET: exportShapefileFromQuery
 			SpatialDatabaseService spatialService = new SpatialDatabaseService(database);


### PR DESCRIPTION
Fixed tests by limiting fork and thread count to 1 (needed to upgrade maven-surefire-plugin to a version >2.16 to make the forkCount parameter work) and setting GraphDatabaseSettings.batch_inserter_batch_size to a maximum value of 2. Any larger value lead to 'PropertyRecord[1] not in usePropertyRecord[1] not in use' errors in many tests.