### PR TITLE
Refactored OSMImporter.isOneway() to OSMImporter.getRoadDirection(), …

### DIFF
--- a/src/main/java/org/neo4j/gis/spatial/osm/OSMImporter.java
+++ b/src/main/java/org/neo4j/gis/spatial/osm/OSMImporter.java
@@ -684,7 +684,7 @@ public class OSMImporter implements Constants
         protected void createOSMWay( Map<String, Object> wayProperties,
                 ArrayList<Long> wayNodes, LinkedHashMap<String, Object> wayTags )
         {
-            RoadDirection direction = isOneway( wayTags );
+            RoadDirection direction = getRoadDirection( wayTags );
             String name = (String) wayTags.get( "name" );
             int geometry = GTYPE_LINESTRING;
             boolean isRoad = wayTags.containsKey( "highway" );
@@ -2114,12 +2114,13 @@ public class OSMImporter implements Constants
     }
 
     /**
-     * Detects if road has the only direction
-     * 
-     * @param wayProperties
-     * @return RoadDirection
+     * Retrieves the direction of the given road, i.e. whether it is a one-way road from its start node,
+     * a one-way road to its start node or a two-way road.
+     * @param wayProperties the property map of the road
+     * @return BOTH if it's a two-way road, FORWARD if it's a one-way road from the start node,
+     * or BACKWARD if it's a one-way road to the start node
      */
-    public static RoadDirection isOneway( Map<String, Object> wayProperties )
+    public static RoadDirection getRoadDirection( Map<String, Object> wayProperties )
     {
         String oneway = (String) wayProperties.get( "oneway" );
         if ( null != oneway )

--- a/src/main/java/org/neo4j/gis/spatial/osm/OSMImporter.java
+++ b/src/main/java/org/neo4j/gis/spatial/osm/OSMImporter.java
@@ -2132,6 +2132,15 @@ public class OSMImporter implements Constants
         }
         return RoadDirection.BOTH;
     }
+    
+    /**
+     * Legacy version of {@link #getRoadDirection(Map)}, for code using it under the old name.
+     * @param wayProperties the property map of the road
+     * @return same as {@link #getRoadDirection(Map)}
+     */
+    public static RoadDirection isOneway(Map<String, Object> wayProperties) {
+    	return getRoadDirection(wayProperties);
+    }
 
     /**
      * Calculate correct distance between 2 points on Earth.


### PR DESCRIPTION
…changed Javadoc.

My proposed solution to #231.

Perhaps a new method isOneway() redelegating to getRoadDirection() should be added though, for those using the method from outside. Because references outside of Neo4j Spatial most probably won't be auto-updated.
Unfortunately, I thought of that too late...