### PR TITLE
Force the locale for the tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
                     <threadCount>1</threadCount>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
-                    <argLine>-server -Xms512m -Xmx1024m</argLine>
+                    <argLine>-server -Xms512m -Xmx1024m -Duser.language=en -Duser.country=US</argLine>
                 </configuration>
             </plugin>
         </plugins>
@@ -650,7 +650,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.18.1</version>
                 <configuration>
-                    <argLine>-server -Xms512m -Xmx2G -XX:+UseConcMarkSweepGC</argLine>
+                    <argLine>-server -Xms512m -Xmx2G -XX:+UseConcMarkSweepGC -Duser.language=en -Duser.country=US</argLine>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
The tests in ProgressLoggingListenerTest depend on the locale picked by the
JVM, because they compare the formatting of floating-point numbers. In
locales where the decimal separator is not the point, such as French (which
uses the comma), the tests fail.

Fixes #271
