### PR TITLE
updating to Neo4j 3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <properties>
-        <neo4j.version>3.0.4</neo4j.version>
-        <neo4j.java.version>1.7</neo4j.java.version>
+        <neo4j.version>3.1.0</neo4j.version>
+        <neo4j.java.version>1.8</neo4j.java.version>
         <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
         <maven-gpg-plugin.version>1.4</maven-gpg-plugin.version>
         <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-spatial</artifactId>
     <groupId>org.neo4j</groupId>
-    <version>0.23-neo4j-3.0.4</version>
+    <version>0.24-neo4j-3.1.0</version>
     <name>Neo4j - Spatial Components</name>
     <description>Spatial utilities and components for Neo4j</description>
     <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>
@@ -336,11 +336,12 @@
             <version>1.1</version>
             <type>jar</type>
         </dependency>
-<!--        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version></version>
-        </dependency>-->
+
+        <!--        <dependency>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                    <version></version>
+                </dependency>-->
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/java/org/neo4j/gis/spatial/procedures/SpatialProcedures.java
+++ b/src/main/java/org/neo4j/gis/spatial/procedures/SpatialProcedures.java
@@ -25,7 +25,7 @@ import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.io.ParseException;
 import com.vividsolutions.jts.io.WKTReader;
-import org.neo4j.cypher.internal.compiler.v3_0.GeographicPoint;
+import org.neo4j.cypher.internal.compiler.v3_1.GeographicPoint;
 import org.neo4j.gis.spatial.*;
 import org.neo4j.gis.spatial.encoders.SimpleGraphEncoder;
 import org.neo4j.gis.spatial.encoders.SimplePointEncoder;
@@ -150,7 +150,7 @@ public class SpatialProcedures {
     public Stream<NameResult> listProcedures() {
         Procedures procedures = ((GraphDatabaseAPI)db).getDependencyResolver().resolveDependency( Procedures.class );
         Stream.Builder<NameResult> builder = Stream.builder();
-        for (ProcedureSignature proc : procedures.getAll()) {
+        for (ProcedureSignature proc : procedures.getAllProcedures()) {
             if (proc.name().namespace()[0].equals("spatial")) {
                 builder.accept(new NameResult(proc.name().toString(), proc.toString()));
             }
@@ -645,15 +645,15 @@ public class SpatialProcedures {
         throw new RuntimeException("Can't convert " + value + " to a geometry");
     }
 
-    private org.neo4j.cypher.internal.compiler.v3_0.Geometry makeCypherGeometry(double x, double y, org.neo4j.cypher.internal.compiler.v3_0.CRS crs) {
-        if (crs.equals(org.neo4j.cypher.internal.compiler.v3_0.CRS.Cartesian())) {
-            return new org.neo4j.cypher.internal.compiler.v3_0.CartesianPoint(x, y, crs);
+    private org.neo4j.cypher.internal.compiler.v3_1.Geometry makeCypherGeometry(double x, double y, org.neo4j.cypher.internal.compiler.v3_1.CRS crs) {
+        if (crs.equals(org.neo4j.cypher.internal.compiler.v3_1.CRS.Cartesian())) {
+            return new org.neo4j.cypher.internal.compiler.v3_1.CartesianPoint(x, y, crs);
         } else {
-            return new org.neo4j.cypher.internal.compiler.v3_0.GeographicPoint(x, y, crs);
+            return new org.neo4j.cypher.internal.compiler.v3_1.GeographicPoint(x, y, crs);
         }
     }
 
-    private org.neo4j.cypher.internal.compiler.v3_0.Geometry makeCypherGeometry(Geometry geometry, org.neo4j.cypher.internal.compiler.v3_0.CRS crs) {
+    private org.neo4j.cypher.internal.compiler.v3_1.Geometry makeCypherGeometry(Geometry geometry, org.neo4j.cypher.internal.compiler.v3_1.CRS crs) {
         if (geometry.getGeometryType().toLowerCase().equals("point")) {
             Coordinate coordinate = geometry.getCoordinates()[0];
             return makeCypherGeometry(coordinate.getOrdinate(0), coordinate.getOrdinate(1), crs);
@@ -662,27 +662,27 @@ public class SpatialProcedures {
         }
     }
 
-    private org.neo4j.cypher.internal.compiler.v3_0.Geometry toCypherGeometry(Layer layer, Object value) {
-        if (value instanceof org.neo4j.cypher.internal.compiler.v3_0.Geometry) {
-            return (org.neo4j.cypher.internal.compiler.v3_0.Geometry) value;
+    private org.neo4j.cypher.internal.compiler.v3_1.Geometry toCypherGeometry(Layer layer, Object value) {
+        if (value instanceof org.neo4j.cypher.internal.compiler.v3_1.Geometry) {
+            return (org.neo4j.cypher.internal.compiler.v3_1.Geometry) value;
         }
         if ( value instanceof org.neo4j.graphdb.spatial.Point) {
             org.neo4j.graphdb.spatial.Point point = (org.neo4j.graphdb.spatial.Point) value;
             List<Double> coord = point.getCoordinate().getCoordinate();
-            return makeCypherGeometry(coord.get(0), coord.get(1), org.neo4j.cypher.internal.compiler.v3_0.CRS.fromSRID(point.getCRS().getCode()));
+            return makeCypherGeometry(coord.get(0), coord.get(1), org.neo4j.cypher.internal.compiler.v3_1.CRS.fromSRID(point.getCRS().getCode()));
         }
-        org.neo4j.cypher.internal.compiler.v3_0.CRS crs = org.neo4j.cypher.internal.compiler.v3_0.CRS.Cartesian();
+        org.neo4j.cypher.internal.compiler.v3_1.CRS crs = org.neo4j.cypher.internal.compiler.v3_1.CRS.Cartesian();
         if (layer != null) {
             CoordinateReferenceSystem layerCRS = layer.getCoordinateReferenceSystem();
             if (layerCRS != null) {
                 ReferenceIdentifier crsRef = layer.getCoordinateReferenceSystem().getName();
-                crs = org.neo4j.cypher.internal.compiler.v3_0.CRS.fromName(crsRef.toString());
+                crs = org.neo4j.cypher.internal.compiler.v3_1.CRS.fromName(crsRef.toString());
             }
         }
         if (value instanceof Geometry) {
             Geometry geometry = (Geometry) value;
             if (geometry.getSRID() > 0) {
-                crs = org.neo4j.cypher.internal.compiler.v3_0.CRS.fromSRID(geometry.getSRID());
+                crs = org.neo4j.cypher.internal.compiler.v3_1.CRS.fromSRID(geometry.getSRID());
             }
             if (geometry instanceof Point) {
                 Point point = (Point) geometry;
@@ -704,7 +704,7 @@ public class SpatialProcedures {
         if (value instanceof PropertyContainer) {
             latLon = ((PropertyContainer) value).getProperties("latitude", "longitude", "lat", "lon");
             if (layer == null) {
-                crs = org.neo4j.cypher.internal.compiler.v3_0.CRS.WGS84();
+                crs = org.neo4j.cypher.internal.compiler.v3_1.CRS.WGS84();
             }
         }
         if (value instanceof Map) latLon = (Map<String, Object>) value;

--- a/src/test/java/org/neo4j/gis/spatial/AsciiDocGenerator.java
+++ b/src/test/java/org/neo4j/gis/spatial/AsciiDocGenerator.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.gis.spatial;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+
+/**
+ * Generate asciidoc-formatted documentation from HTTP requests and responses.
+ * The status and media type of all responses is checked as well as the
+ * existence of any expected headers.
+ *
+ * The filename of the resulting ASCIIDOC test file is derived from the title.
+ *
+ * The title is determined by either a JavaDoc period terminated first title
+ * line, the @Title annotation or the method name, where "_" is replaced by " ".
+ */
+public abstract class AsciiDocGenerator
+{
+    private static final String DOCUMENTATION_END = "\n...\n";
+    private final Logger log = Logger.getLogger( AsciiDocGenerator.class.getName() );
+    protected final String title;
+    protected String section;
+    protected String description = null;
+    protected GraphDatabaseService graph;
+    protected static final String SNIPPET_MARKER = "@@";
+    protected Map<String, String> snippets = new HashMap<String, String>();
+    private static final Map<String, Integer> counters = new HashMap<String, Integer>();
+
+    public AsciiDocGenerator( final String title, final String section )
+    {
+        this.section = section;
+        this.title = title.replace( "_", " " );
+    }
+
+    public AsciiDocGenerator setGraph( GraphDatabaseService graph )
+    {
+        this.graph = graph;
+        return this;
+    }
+
+    public String getTitle()
+    {
+        return title;
+    }
+
+    public AsciiDocGenerator setSection(final String section)
+    {
+        this.section = section;
+        return this;
+    }
+
+    /**
+     * Add a description to the test (in asciidoc format). Adding multiple
+     * descriptions will yield one paragraph per description.
+     *
+     * @param description the description
+     */
+    public AsciiDocGenerator description( final String description )
+    {
+        if ( description == null )
+        {
+            throw new IllegalArgumentException(
+                    "The description can not be null" );
+        }
+        String content;
+        int pos = description.indexOf( DOCUMENTATION_END );
+        if ( pos != -1 )
+        {
+            content = description.substring( 0, pos );
+        }
+        else
+        {
+            content = description;
+        }
+        if ( this.description == null )
+        {
+            this.description = content;
+        }
+        else
+        {
+            this.description += "\n\n" + content;
+        }
+        return this;
+    }
+
+    protected void line( final Writer fw, final String string )
+            throws IOException
+    {
+        fw.append( string );
+        fw.append( "\n" );
+    }
+
+    public static Writer getFW( String dir, String title )
+    {
+        try
+        {
+            File dirs = new File( dir );
+            String name = title.replace( " ", "-" )
+                    .toLowerCase() + ".asciidoc";
+            return getFW( dirs, name );
+        }
+        catch ( Exception e )
+        {
+            e.printStackTrace();
+            throw new RuntimeException( e );
+        }
+    }
+
+    public static Writer getFW( File dir, String filename )
+    {
+        try
+        {
+            if ( !dir.exists() )
+            {
+                dir.mkdirs();
+            }
+            File out = new File( dir, filename );
+            if ( out.exists() )
+            {
+                out.delete();
+            }
+            if ( !out.createNewFile() )
+            {
+                throw new RuntimeException( "File exists: "
+                                            + out.getAbsolutePath() );
+            }
+            return new OutputStreamWriter( new FileOutputStream( out, false ), StandardCharsets.UTF_8 );
+        }
+        catch ( Exception e )
+        {
+            e.printStackTrace();
+            throw new RuntimeException( e );
+        }
+    }
+
+    public static String dumpToSeparateFile( File dir, String testId,
+            String content )
+    {
+        if ( content == null || content.isEmpty() )
+        {
+            throw new IllegalArgumentException( "The content can not be empty(" + content + ")." );
+        }
+        String filename = testId + ".asciidoc";
+        Writer writer = AsciiDocGenerator.getFW( new File( dir, "includes" ), filename );
+        String title = "";
+        char firstChar = content.charAt( 0 );
+        if ( firstChar == '.' || firstChar == '_' )
+        {
+            int pos = content.indexOf( '\n' );
+            if ( pos != -1 )
+            {
+                title = content.substring( 0, pos + 1 );
+                content = content.substring( pos + 1 );
+            }
+        }
+        try
+        {
+            writer.write( content );
+        }
+        catch ( IOException e )
+        {
+            e.printStackTrace();
+        }
+        finally
+        {
+            try
+            {
+                writer.close();
+            }
+            catch ( IOException e )
+            {
+                e.printStackTrace();
+            }
+        }
+        return title + "include::includes/" + filename + "[]\n";
+    }
+
+    public static String dumpToSeparateFileWithType( File dir, String type,
+            String content )
+    {
+        if ( type == null || type.isEmpty() )
+        {
+            throw new IllegalArgumentException(
+                    "The type can not be null or empty: [" + type + "]" );
+        }
+        String key = dir.getAbsolutePath() + type;
+        Integer counter = counters.get( key );
+        if ( counter == null )
+        {
+            counter = 0;
+        }
+        counter++;
+        counters.put( key, counter );
+        String testId = type + "-" + String.valueOf( counter );
+        return dumpToSeparateFile( dir, testId, content );
+    }
+
+    public static PrintWriter getPrintWriter( String dir, String title )
+    {
+        return new PrintWriter( getFW( dir, title ) );
+    }
+
+    public static String getPath( Class<?> source )
+    {
+        return source.getPackage()
+                .getName()
+                .replace( ".", "/" ) + "/" + source.getSimpleName() + ".java";
+    }
+
+    protected String replaceSnippets( String description, File dir, String title )
+    {
+        for (String key : snippets.keySet()) {
+            description = replaceSnippet( description, key, dir, title );
+        }
+        if(description.contains( SNIPPET_MARKER )) {
+            int indexOf = description.indexOf( SNIPPET_MARKER );
+            String snippet = description.substring( indexOf, description.indexOf( "\n", indexOf ) );
+            log.severe( "missing snippet ["+snippet+"] in " + description);
+        }
+        return description;
+    }
+
+    private String replaceSnippet( String description, String key, File dir,
+            String title )
+    {
+        String snippetString = SNIPPET_MARKER + key;
+        if ( description.contains( snippetString + "\n" ) )
+        {
+            String include = dumpToSeparateFile( dir, title + "-" + key,
+                    snippets.get( key ) );
+            description = description.replace( snippetString + "\n", include );
+        } else {
+            log.severe( "Could not find " + snippetString + "\\n in "
+                        + description );
+        }
+        return description;
+    }
+
+    /**
+     * Add snippets that will be replaced into corresponding.
+     *
+     * A snippet needs to be on its own line, terminated by "\n".
+     *
+     * @@snippetname placeholders in the content of the description.
+     *
+     * @param key the snippet key, without @@
+     * @param content the content to be inserted
+     */
+    public void addSnippet( String key, String content )
+    {
+        snippets.put( key, content );
+    }
+
+    /**
+     * Added one or more source snippets from test sources, available from
+     * javadoc using
+     *
+     * @@tagName.
+     *
+     * @param source the class where the snippet is found
+     * @param tagNames the tag names which should be included
+     */
+    public void addTestSourceSnippets( Class<?> source, String... tagNames )
+    {
+        for ( String tagName : tagNames )
+        {
+            addSnippet( tagName, sourceSnippet( tagName, source, "test-sources" ) );
+        }
+    }
+
+    /**
+     * Added one or more source snippets, available from javadoc using
+     *
+     * @@tagName.
+     *
+     * @param source the class where the snippet is found
+     * @param tagNames the tag names which should be included
+     */
+    public void addSourceSnippets( Class<?> source, String... tagNames )
+    {
+        for ( String tagName : tagNames )
+        {
+            addSnippet( tagName, sourceSnippet( tagName, source, "sources" ) );
+        }
+    }
+
+    private static String sourceSnippet( String tagName, Class<?> source,
+            String classifier )
+    {
+        return "[snippet,java]\n" + "----\n"
+               + "component=${project.artifactId}\n" + "source="
+               + getPath( source ) + "\n" + "classifier=" + classifier + "\n"
+               + "tag=" + tagName + "\n" + "----\n";
+    }
+
+    public void addGithubTestSourceLink( String key, Class<?> source,
+            String dir )
+    {
+        githubLink( key, source, dir, "test" );
+    }
+
+    public void addGithubSourceLink( String key, Class<?> source, String dir )
+    {
+        githubLink( key, source, dir, "main" );
+    }
+
+    private void githubLink( String key, Class<?> source, String dir,
+            String mainOrTest )
+    {
+        String path = "https://github.com/neo4j/neo4j/blob/{neo4j-git-tag}/";
+        if ( dir != null )
+        {
+            path += dir + "/";
+        }
+        path += "src/" + mainOrTest + "/java/" + getPath( source );
+        path += "[" + source.getSimpleName() + ".java]\n";
+        addSnippet( key, path );
+    }
+}

--- a/src/test/java/org/neo4j/gis/spatial/JavaTestDocsGenerator.java
+++ b/src/test/java/org/neo4j/gis/spatial/JavaTestDocsGenerator.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.gis.spatial;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+
+import org.neo4j.test.GraphDefinition;
+import org.neo4j.test.TestData.Producer;
+
+
+/**
+ * NB: this class has been copied from main neo4j repo since it's been removed from there in the meantime
+ * This class is supporting the generation of ASCIIDOC documentation
+ * from Java JUnit tests. Snippets can be supplied programmatically in the Java-section
+ * and will replace their @@snippetName placeholders in the documentation description.
+ * 
+ * @author peterneubauer
+ *
+ */
+public class JavaTestDocsGenerator extends AsciiDocGenerator
+{
+    public static final Producer<JavaTestDocsGenerator> PRODUCER = new Producer<JavaTestDocsGenerator>()
+    {
+        @Override
+        public JavaTestDocsGenerator create( GraphDefinition graph,
+                String title, String documentation )
+        {
+            return (JavaTestDocsGenerator) new JavaTestDocsGenerator( title ).description( documentation );
+        }
+
+        @Override
+        public void destroy( JavaTestDocsGenerator product, boolean successful )
+        {
+            // TODO: invoke some complete method here?
+        }
+    };
+    
+    public JavaTestDocsGenerator( String title )
+    {
+        super( title, "docs" );
+    }
+
+    public void document( String directory, String sectionName )
+    {
+        this.setSection( sectionName );
+        String name = title.replace( " ", "-" ).toLowerCase();
+        File dir = new File( new File( directory ), section );
+        String filename = name + ".asciidoc";
+        Writer fw = getFW( dir, filename );
+        description = replaceSnippets( description, dir, name );
+        try
+        {
+            line( fw,
+                    "[[" + sectionName + "-" + name.replaceAll( "\\(|\\)", "" )
+                            + "]]" );
+            String firstChar = title.substring( 0, 1 ).toUpperCase();
+            line( fw, firstChar + title.substring( 1 ) );
+            for ( int i = 0; i < title.length(); i++ )
+            {
+                fw.append( "=" );
+            }
+            fw.append( "\n" );
+            line( fw, "" );
+            line( fw, description );
+            line( fw, "" );
+            fw.flush();
+            fw.close();
+        }
+        catch ( IOException e )
+        {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+    }
+
+    public void addImageSnippet( String tagName, String imageName, String title )
+    {
+        this.addSnippet( tagName, "\nimage:" + imageName + "[" + title + "]\n" );
+    }
+}

--- a/src/test/java/org/neo4j/gis/spatial/Neo4jTestCase.java
+++ b/src/test/java/org/neo4j/gis/spatial/Neo4jTestCase.java
@@ -44,7 +44,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;
-import org.neo4j.test.EphemeralFileSystemRule;
+import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 import org.neo4j.unsafe.batchinsert.BatchInserter;
 import org.neo4j.unsafe.batchinsert.BatchInserters;
 

--- a/src/test/java/org/neo4j/gis/spatial/ProgressLoggingListenerTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/ProgressLoggingListenerTest.java
@@ -59,7 +59,7 @@ public class ProgressLoggingListenerTest {
         }
         listener.done();
         verify(out).println("Starting test");
-        verify(out).println("100.00 (10/10) - Completed test");
+        verify(out).println(String.format("%.2f (10/10) - Completed test", 100f));
         verify(out, times(expectedLogCount)).println(anyString());
     }
 }

--- a/src/test/java/org/neo4j/gis/spatial/SpatialPluginFunctionalTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/SpatialPluginFunctionalTest.java
@@ -19,17 +19,12 @@
  */
 package org.neo4j.gis.spatial;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import javax.ws.rs.core.Response.Status;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -40,8 +35,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.Result;
-import org.neo4j.helpers.HostnamePort;
+import org.neo4j.helpers.ListenSocketAddress;
 import org.neo4j.kernel.impl.annotations.Documented;
 import org.neo4j.server.NeoServer;
 import org.neo4j.server.helpers.CommunityServerBuilder;
@@ -64,7 +58,7 @@ public class SpatialPluginFunctionalTest extends AbstractRestFunctionalTestBase
      */
     @BeforeClass
     public static void allocateServer() throws IOException {
-        altServer = CommunityServerBuilder.server().onAddress( new HostnamePort( "localhost", PORT ) ).build();
+        altServer = CommunityServerBuilder.server().onAddress( new ListenSocketAddress( "localhost", PORT ) ).build();
         altServer.start();
     }
 
@@ -238,7 +232,7 @@ public class SpatialPluginFunctionalTest extends AbstractRestFunctionalTestBase
         ImpermanentGraphDatabase graphdb = (ImpermanentGraphDatabase) graphdb();
         graphdb.cleanContent();
         //clean
-        gen.get().setGraph( graphdb() );
+        // gen.get().setGraph( graphdb() ); // FIXME
         
     }
     

--- a/src/test/java/org/neo4j/gis/spatial/procedures/SpatialProceduresTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/procedures/SpatialProceduresTest.java
@@ -120,7 +120,7 @@ public class SpatialProceduresTest {
     }
 
     public static void registerProcedure(GraphDatabaseService db, Class<?> procedure) throws KernelException {
-        ((GraphDatabaseAPI) db).getDependencyResolver().resolveDependency(Procedures.class).register(procedure);
+        ((GraphDatabaseAPI) db).getDependencyResolver().resolveDependency(Procedures.class).registerProcedure(procedure);
     }
 
     @Test
@@ -206,7 +206,8 @@ public class SpatialProceduresTest {
     public void create_node_decode_to_geometry() {
         execute("CALL spatial.addWKTLayer('geom','geom')");
         ResourceIterator<Object> results = db.execute("CREATE (n:Node {geom:'POINT(4.0 5.0)'}) WITH n CALL spatial.decodeGeometry('geom',n) YIELD geometry RETURN geometry").columnAs("geometry");
-        assertThat("Should be Geometry type", results.next(), instanceOf(Geometry.class));
+        Object actual = results.next();
+        assertThat("Should be Geometry type", actual, instanceOf(Geometry.class));
         results.close();
     }
 


### PR DESCRIPTION
This PR updates the Neo4j dependencies to 3.1.0 and addresses all compile/test issues caused. Tests are going green. However I have not yet done any other testing aside from `mvn test`.