### PR TITLE
Do not exclude org.geotools:gt-cql in assembly descriptor

### DIFF
--- a/src/main/assembly/server-plugin.xml
+++ b/src/main/assembly/server-plugin.xml
@@ -36,7 +36,6 @@
         <exclude>org.geotools:gt-process</exclude>
         <exclude>org.geotools:gt-render</exclude>
         <exclude>org.geotools:gt-coverage</exclude>
-        <exclude>org.geotools:gt-cql</exclude>
         <exclude>javax.media:jai_imageio</exclude>
       </excludes>
     </dependencySet>


### PR DESCRIPTION
I want to resolve #293.