### PR TITLE
Port to Neo4j 4.1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,14 @@ This has meant that the spatial library needed a major refactoring to work with 
   It was therefor necessary to upgrade the GeoTools libraries to version 24.2.
   This in turn required a re-write of the Neo4jDataStore interface since the older API had
   long been deprecated, and was entirely unavailable in newer versions.
+* Neo4j 4.1 was slightly stricter with regards to passing nodes as parameters, requiring the nodes
+  objects to have been created in the current transaction.
+  To work around this we added `.byId` versions of the `spatial.addNode` and `spatial.removeNode` procedures.
+  We also changed the `spatial.removeNode` procedures to return `nodeId` instead of `node`.
 
-Consequences of this port:
+Consequences of the port to Neo4j 4.x:
 
-* The large number of changes mean that the 0.27.0 version should be considered very alpha.
+* The large number of changes mean that the 0.27.x versions should be considered very alpha.
 * Many API's have changed and client code might need to be adapted to take the changes into account.
 * The new DataStore API is entirely untested in GeoServer, besides the existing unit and integration tests.
 * The need to manage threads and create schema indexes results in the procedures requiring
@@ -335,6 +339,7 @@ The Neo4j Spatial Plugin is available for inclusion in the server version of Neo
   * [v0.26.2 for Neo4j 3.5.2](https://github.com/neo4j-contrib/m2/blob/master/releases/org/neo4j/neo4j-spatial/0.26.2-neo4j-3.5.2/neo4j-spatial-0.26.2-neo4j-3.5.2-server-plugin.jar?raw=true)
 * Using GeoTools 24.2 (for GeoServer 2.18.x):
   * [v0.27.0 for Neo4j 4.0.3](https://github.com/neo4j-contrib/m2/blob/master/releases/org/neo4j/neo4j-spatial/0.27.0-neo4j-4.0.3/neo4j-spatial-0.27.0-neo4j-4.0.3-server-plugin.jar?raw=true)
+  * [v0.27.1 for Neo4j 4.1.7](https://github.com/neo4j-contrib/m2/blob/master/releases/org/neo4j/neo4j-spatial/0.27.1-neo4j-4.1.7/neo4j-spatial-0.27.1-neo4j-4.1.7-server-plugin.jar?raw=true)
 
 For versions up to 0.15-neo4j-2.3.4:
 
@@ -451,7 +456,7 @@ Add the following repositories and dependency to your project's pom.xml:
     <dependency>
         <groupId>org.neo4j</groupId>
         <artifactId>neo4j-spatial</artifactId>
-        <version>0.27.0-neo4j-4.0.3</version>
+        <version>0.27.1-neo4j-4.1.7</version>
     </dependency>
 ~~~
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <properties>
-        <neo4j.version>4.0.3</neo4j.version>
+        <neo4j.version>4.1.7</neo4j.version>
         <lucene.version>8.2.0</lucene.version>
         <!-- make sure lucene version is the same as the one the current neo4j depends on -->
         <neo4j.java.version>11</neo4j.java.version>
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-spatial</artifactId>
     <groupId>org.neo4j</groupId>
-    <version>0.27.0-neo4j-4.0.3</version>
+    <version>0.27.1-neo4j-4.1.7</version>
     <name>Neo4j - Spatial Components</name>
     <description>Spatial utilities and components for Neo4j</description>
     <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/src/main/java/org/neo4j/gis/spatial/AbstractGeometryEncoder.java
+++ b/src/main/java/org/neo4j/gis/spatial/AbstractGeometryEncoder.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.gis.spatial;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.neo4j.gis.spatial.rtree.Envelope;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Entity;

--- a/src/main/java/org/neo4j/gis/spatial/index/IndexManager.java
+++ b/src/main/java/org/neo4j/gis/spatial/index/IndexManager.java
@@ -150,14 +150,14 @@ public class IndexManager {
         @Override
         public void run() {
             try {
-                try (Transaction tx = db.beginTransaction(KernelTransaction.Type.explicit, securityContext)) {
+                try (Transaction tx = db.beginTransaction(KernelTransaction.Type.EXPLICIT, securityContext)) {
                     index = findIndex(tx);
                     if (index == null) {
                         index = tx.schema().indexFor(label).withName(indexName).on(propertyKey).create();
                     }
                     tx.commit();
                 }
-                try (Transaction tx = db.beginTransaction(KernelTransaction.Type.explicit, securityContext)) {
+                try (Transaction tx = db.beginTransaction(KernelTransaction.Type.EXPLICIT, securityContext)) {
                     tx.schema().awaitIndexOnline(indexName, 30, TimeUnit.SECONDS);
                 }
             } catch (Exception e) {
@@ -208,7 +208,7 @@ public class IndexManager {
         @Override
         public void run() {
             try {
-                try (Transaction tx = db.beginTransaction(KernelTransaction.Type.explicit, securityContext)) {
+                try (Transaction tx = db.beginTransaction(KernelTransaction.Type.EXPLICIT, securityContext)) {
                     // Need to find and drop in the same transaction due to saved state in the index definition implementation
                     IndexDefinition found = tx.schema().getIndexByName(index.getName());
                     if (found != null) {

--- a/src/main/java/org/neo4j/gis/spatial/index/LayerSpaceFillingCurvePointIndex.java
+++ b/src/main/java/org/neo4j/gis/spatial/index/LayerSpaceFillingCurvePointIndex.java
@@ -26,13 +26,16 @@ import org.neo4j.gis.spatial.index.curves.SpaceFillingCurve;
 import org.neo4j.gis.spatial.index.curves.StandardConfiguration;
 import org.neo4j.gis.spatial.rtree.filter.AbstractSearchEnvelopeIntersection;
 import org.neo4j.gis.spatial.rtree.filter.SearchFilter;
-import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.internal.helpers.collection.Iterators;
 import org.neo4j.internal.kernel.api.*;
 import org.neo4j.internal.schema.IndexDescriptor;
-import org.neo4j.internal.schema.IndexOrder;
 import org.neo4j.internal.schema.IndexType;
 import org.neo4j.internal.schema.SchemaDescriptor;
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.impl.core.NodeEntity;
 import org.neo4j.kernel.impl.coreapi.internal.NodeCursorResourceIterator;
@@ -142,9 +145,9 @@ public abstract class LayerSpaceFillingCurvePointIndex extends ExplicitIndexBack
                 // Ha! We found an index - let's use it to find matching nodes
                 try
                 {
-                    NodeValueIndexCursor cursor = transaction.cursors().allocateNodeValueIndexCursor();
+                    NodeValueIndexCursor cursor = transaction.cursors().allocateNodeValueIndexCursor(PageCursorTracer.NULL);
                     IndexReadSession indexSession = read.indexReadSession( index );
-                    read.nodeIndexSeek( indexSession, cursor, IndexOrder.NONE, false, query );
+                    read.nodeIndexSeek( indexSession, cursor, IndexQueryConstraints.unordered(false), query );
 
                     return new NodeCursorResourceIterator<>( cursor, (id) -> new NodeEntity(transaction.internalTransaction(), id) );
                 }

--- a/src/main/java/org/neo4j/gis/spatial/osm/OSMImporter.java
+++ b/src/main/java/org/neo4j/gis/spatial/osm/OSMImporter.java
@@ -33,13 +33,11 @@ import org.neo4j.graphdb.*;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.graphdb.traversal.Evaluators;
 import org.neo4j.graphdb.traversal.TraversalDescription;
-import org.neo4j.internal.kernel.api.security.AccessMode;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.io.layout.DatabaseLayout;
 import org.neo4j.io.layout.Neo4jLayout;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.impl.api.security.OverriddenAccessMode;
 import org.neo4j.kernel.impl.traversal.MonoDirectionalTraversalDescription;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 
@@ -202,7 +200,7 @@ public class OSMImporter implements Constants {
         if (!(database instanceof GraphDatabaseAPI)) {
             throw new IllegalArgumentException("database must implement GraphDatabaseAPI");
         }
-        return ((GraphDatabaseAPI) database).beginTransaction(KernelTransaction.Type.explicit, securityContext);
+        return ((GraphDatabaseAPI) database).beginTransaction(KernelTransaction.Type.EXPLICIT, securityContext);
     }
 
     public long reIndex(GraphDatabaseService database) {
@@ -902,7 +900,7 @@ public class OSMImporter implements Constants {
             if (!(database instanceof GraphDatabaseAPI)) {
                 throw new IllegalArgumentException("database must implement GraphDatabaseAPI");
             }
-            return ((GraphDatabaseAPI) database).beginTransaction(KernelTransaction.Type.explicit, securityContext);
+            return ((GraphDatabaseAPI) database).beginTransaction(KernelTransaction.Type.EXPLICIT, securityContext);
         }
 
         private void beginTx() {

--- a/src/test/java/org/neo4j/gis/spatial/Neo4jTestCase.java
+++ b/src/test/java/org/neo4j/gis/spatial/Neo4jTestCase.java
@@ -56,8 +56,6 @@ public abstract class Neo4jTestCase {
         //NORMAL_CONFIG.put( GraphDatabaseSettings.strings_mapped_memory_size.name(), "200M" );
         //NORMAL_CONFIG.put( GraphDatabaseSettings.arrays_mapped_memory_size.name(), "0M" );
         NORMAL_CONFIG.put(GraphDatabaseSettings.pagecache_memory.name(), "200M");
-        NORMAL_CONFIG.put(GraphDatabaseSettings.batch_inserter_batch_size.name(), "2");
-        NORMAL_CONFIG.put(GraphDatabaseSettings.dump_configuration.name(), "false");
     }
 
     static final Map<String, String> LARGE_CONFIG = new HashMap<>();
@@ -69,8 +67,6 @@ public abstract class Neo4jTestCase {
         //LARGE_CONFIG.put( GraphDatabaseSettings.strings_mapped_memory_size.name(), "800M" );
         //LARGE_CONFIG.put( GraphDatabaseSettings.arrays_mapped_memory_size.name(), "10M" );
         LARGE_CONFIG.put(GraphDatabaseSettings.pagecache_memory.name(), "100M");
-        LARGE_CONFIG.put(GraphDatabaseSettings.batch_inserter_batch_size.name(), "2");
-        LARGE_CONFIG.put(GraphDatabaseSettings.dump_configuration.name(), "true");
     }
 
     private static final File basePath = new File("target/var");


### PR DESCRIPTION
Most some internal API changes:
* Transaction type names
* IndexSeek API change
* Stricter checks on parameters containing Node objects

This last change means that if we return a Node from one transaction, we cannot pass it into a spatial procedure in another transaction. Users have to either lookup the node again in the new transaction, or use some new procedures we provide here:

* spatial.addNode.byId
* spatial.addNodes.byId
* spatial.removeNode.byId
* spatial.removeNodes.byId

Also the removeNode procedures now return `nodeId` instead of `node`