### PR TITLE
Port to Neo4j 4.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ This has meant that the spatial library needed a major refactoring to work with 
   objects to have been created in the current transaction.
   To work around this we added `.byId` versions of the `spatial.addNode` and `spatial.removeNode` procedures.
   We also changed the `spatial.removeNode` procedures to return `nodeId` instead of `node`.
+* The change to Neo4j 4.2 was more subtle. Mostly only internal API's around the use of `Path` instead of `File`.
+  One change that could be noticed was the `IndexManager.IndexAccessMode` class.
+  In the 0.27.0 and 0.27.1 versions we used `OverridenAccessMode` to take the users existing access mode
+  and simply add on the rights to create tokens and indexes. In 0.27.2 we instead use `RestrictedAccessMode`
+  to restrict the users access right to the built in `AccessModel.Static.SCHEMA` and then boost to enable
+  index and token writes. The difference is subtle and should only be possible to notice in Enterprise Edition.
 
 Consequences of the port to Neo4j 4.x:
 
@@ -340,6 +346,7 @@ The Neo4j Spatial Plugin is available for inclusion in the server version of Neo
 * Using GeoTools 24.2 (for GeoServer 2.18.x):
   * [v0.27.0 for Neo4j 4.0.3](https://github.com/neo4j-contrib/m2/blob/master/releases/org/neo4j/neo4j-spatial/0.27.0-neo4j-4.0.3/neo4j-spatial-0.27.0-neo4j-4.0.3-server-plugin.jar?raw=true)
   * [v0.27.1 for Neo4j 4.1.7](https://github.com/neo4j-contrib/m2/blob/master/releases/org/neo4j/neo4j-spatial/0.27.1-neo4j-4.1.7/neo4j-spatial-0.27.1-neo4j-4.1.7-server-plugin.jar?raw=true)
+  * [v0.27.2 for Neo4j 4.2.3](https://github.com/neo4j-contrib/m2/blob/master/releases/org/neo4j/neo4j-spatial/0.27.2-neo4j-4.2.3/neo4j-spatial-0.27.2-neo4j-4.2.3-server-plugin.jar?raw=true)
 
 For versions up to 0.15-neo4j-2.3.4:
 
@@ -456,7 +463,7 @@ Add the following repositories and dependency to your project's pom.xml:
     <dependency>
         <groupId>org.neo4j</groupId>
         <artifactId>neo4j-spatial</artifactId>
-        <version>0.27.1-neo4j-4.1.7</version>
+        <version>0.27.2-neo4j-4.2.3</version>
     </dependency>
 ~~~
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <properties>
-        <neo4j.version>4.1.7</neo4j.version>
+        <neo4j.version>4.2.3</neo4j.version>
         <lucene.version>8.2.0</lucene.version>
         <!-- make sure lucene version is the same as the one the current neo4j depends on -->
         <neo4j.java.version>11</neo4j.java.version>
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-spatial</artifactId>
     <groupId>org.neo4j</groupId>
-    <version>0.27.1-neo4j-4.1.7</version>
+    <version>0.27.2-neo4j-4.2.3</version>
     <name>Neo4j - Spatial Components</name>
     <description>Spatial utilities and components for Neo4j</description>
     <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/src/main/java/org/neo4j/gis/spatial/index/IndexManager.java
+++ b/src/main/java/org/neo4j/gis/spatial/index/IndexManager.java
@@ -6,7 +6,7 @@ import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.internal.kernel.api.security.PrivilegeAction;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.impl.api.security.OverriddenAccessMode;
+import org.neo4j.kernel.impl.api.security.RestrictedAccessMode;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 
 import java.util.List;
@@ -17,13 +17,13 @@ public class IndexManager {
     private final GraphDatabaseAPI db;
     private final SecurityContext securityContext;
 
-    public static class IndexAccessMode extends OverriddenAccessMode {
+    public static class IndexAccessMode extends RestrictedAccessMode {
         public static SecurityContext withIndexCreate(SecurityContext securityContext) {
             return securityContext.withMode(new IndexAccessMode(securityContext));
         }
 
         private IndexAccessMode(SecurityContext securityContext) {
-            super(Static.ACCESS, securityContext.mode());
+            super(securityContext.mode(), Static.SCHEMA);
         }
 
         @Override

--- a/src/main/java/org/neo4j/gis/spatial/index/LayerSpaceFillingCurvePointIndex.java
+++ b/src/main/java/org/neo4j/gis/spatial/index/LayerSpaceFillingCurvePointIndex.java
@@ -39,6 +39,7 @@ import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.impl.core.NodeEntity;
 import org.neo4j.kernel.impl.coreapi.internal.NodeCursorResourceIterator;
+import org.neo4j.memory.EmptyMemoryTracker;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.cs.CoordinateSystemAxis;
 
@@ -145,7 +146,7 @@ public abstract class LayerSpaceFillingCurvePointIndex extends ExplicitIndexBack
                 // Ha! We found an index - let's use it to find matching nodes
                 try
                 {
-                    NodeValueIndexCursor cursor = transaction.cursors().allocateNodeValueIndexCursor(PageCursorTracer.NULL);
+                    NodeValueIndexCursor cursor = transaction.cursors().allocateNodeValueIndexCursor(PageCursorTracer.NULL, EmptyMemoryTracker.INSTANCE);
                     IndexReadSession indexSession = read.indexReadSession( index );
                     read.nodeIndexSeek( indexSession, cursor, IndexQueryConstraints.unordered(false), query );
 

--- a/src/main/java/org/neo4j/gis/spatial/osm/OSMImporter.java
+++ b/src/main/java/org/neo4j/gis/spatial/osm/OSMImporter.java
@@ -1635,11 +1635,11 @@ public class OSMImporter implements Constants {
         }
 
         private DatabaseLayout prepareLayout(boolean delete) throws IOException {
-            Neo4jLayout homeLayout = Neo4jLayout.of(dbPath);
+            Neo4jLayout homeLayout = Neo4jLayout.of(dbPath.toPath());
             DatabaseLayout databaseLayout = homeLayout.databaseLayout(databaseName);
             if (delete) {
-                FileUtils.deleteRecursively(databaseLayout.databaseDirectory());
-                FileUtils.deleteRecursively(databaseLayout.getTransactionLogsDirectory());
+                FileUtils.deleteDirectory(databaseLayout.databaseDirectory());
+                FileUtils.deleteDirectory(databaseLayout.getTransactionLogsDirectory());
             }
             return databaseLayout;
         }
@@ -1647,7 +1647,7 @@ public class OSMImporter implements Constants {
         private void prepareDatabase(boolean delete) throws IOException {
             shutdown();
             prepareLayout(delete);
-            databases = new DatabaseManagementServiceBuilder(dbPath).build();
+            databases = new DatabaseManagementServiceBuilder(dbPath.toPath()).build();
             graphDb = databases.database(databaseName);
         }
 

--- a/src/test/java/org/neo4j/gis/spatial/LayersTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/LayersTest.java
@@ -63,7 +63,7 @@ public class LayersTest {
 
     @Before
     public void setup() throws KernelException {
-        databases = new TestDatabaseManagementServiceBuilder(new File("target/layers")).impermanent().build();
+        databases = new TestDatabaseManagementServiceBuilder(new File("target/layers").toPath()).impermanent().build();
         graphDb = databases.database(DEFAULT_DATABASE_NAME);
         ((GraphDatabaseAPI) graphDb).getDependencyResolver().resolveDependency(GlobalProcedures.class).registerProcedure(SpatialProcedures.class);
     }

--- a/src/test/java/org/neo4j/gis/spatial/Neo4jSpatialDataStoreTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/Neo4jSpatialDataStoreTest.java
@@ -18,9 +18,9 @@ import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 
 import javax.xml.stream.XMLStreamException;
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -36,7 +36,7 @@ public class Neo4jSpatialDataStoreTest {
 
     @Before
     public void setup() throws IOException, XMLStreamException {
-        this.databases = new TestDatabaseManagementServiceBuilder(new File("target/test")).impermanent().build();
+        this.databases = new TestDatabaseManagementServiceBuilder(Path.of("target", "test")).impermanent().build();
         this.graph = databases.database(DEFAULT_DATABASE_NAME);
         OSMImporter importer = new OSMImporter("map", new ConsoleListener());
         importer.setCharset(StandardCharsets.UTF_8);
@@ -65,7 +65,7 @@ public class Neo4jSpatialDataStoreTest {
     public void shouldOpenDataStoreOnNonSpatialDatabase() {
         DatabaseManagementService otherDatabases = null;
         try {
-            otherDatabases = new TestDatabaseManagementServiceBuilder(new File("target/other-db")).impermanent().build();
+            otherDatabases = new TestDatabaseManagementServiceBuilder(Path.of("target", "other-db")).impermanent().build();
             GraphDatabaseService otherGraph = otherDatabases.database(DEFAULT_DATABASE_NAME);
             Neo4jSpatialDataStore store = new Neo4jSpatialDataStore(otherGraph);
             ReferencedEnvelope bounds = store.getBounds("map");

--- a/src/test/java/org/neo4j/gis/spatial/Neo4jTestCase.java
+++ b/src/test/java/org/neo4j/gis/spatial/Neo4jTestCase.java
@@ -37,6 +37,7 @@ import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -70,7 +71,7 @@ public abstract class Neo4jTestCase {
     }
 
     private static final File basePath = new File("target/var");
-    private static final File dbPath = new File(basePath, "neo4j-db");
+    private static final Path dbPath = new File(basePath, "neo4j-db").toPath();
     private DatabaseManagementService databases;
     private GraphDatabaseService graphDb;
 
@@ -124,8 +125,8 @@ public abstract class Neo4jTestCase {
         Neo4jLayout homeLayout = Neo4jLayout.of(dbPath);
         DatabaseLayout databaseLayout = homeLayout.databaseLayout(DEFAULT_DATABASE_NAME);
         if (delete) {
-            FileUtils.deleteRecursively(databaseLayout.databaseDirectory());
-            FileUtils.deleteRecursively(databaseLayout.getTransactionLogsDirectory());
+            FileUtils.deleteDirectory(databaseLayout.databaseDirectory());
+            FileUtils.deleteDirectory(databaseLayout.getTransactionLogsDirectory());
         }
         return databaseLayout;
     }
@@ -141,7 +142,7 @@ public abstract class Neo4jTestCase {
 
     @Before
     public void before() throws Exception {
-        fileSystemRule.get().mkdirs(new File("target"));
+        fileSystemRule.get().mkdirs(new File("target").toPath());
     }
 
     @After
@@ -152,17 +153,17 @@ public abstract class Neo4jTestCase {
     private void beforeShutdown() {
     }
 
-    File getNeoPath() {
-        return new File(dbPath.getAbsolutePath());
+    Path getNeoPath() {
+        return dbPath.toAbsolutePath();
     }
 
-    File getDbPath() {
-        return new File(dbPath.getAbsolutePath(), "test-" + storePrefix);
+    Path getDbPath() {
+        return dbPath.toAbsolutePath().resolve("test-" + storePrefix);
     }
 
     private void deleteDatabase() {
         try {
-            FileUtils.deleteRecursively(getNeoPath());
+            FileUtils.deleteDirectory(getNeoPath());
         } catch (IOException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
@@ -189,7 +190,7 @@ public abstract class Neo4jTestCase {
     }
 
     void printDatabaseStats() {
-        Neo4jTestUtils.printDatabaseStats(graphDb(), getDbPath());
+        Neo4jTestUtils.printDatabaseStats(graphDb(), getDbPath().toFile());
     }
 
     protected GraphDatabaseService graphDb() {

--- a/src/test/java/org/neo4j/gis/spatial/OsmAnalysisTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/OsmAnalysisTest.java
@@ -138,7 +138,7 @@ public class OsmAnalysisTest extends TestOSMImport {
                 System.out.println("Failed to delete previous database directory '" + dbDir + "': " + e.getMessage());
             }
         }
-        databases = new TestDatabaseManagementServiceBuilder(dbDir).impermanent().build();
+        databases = new TestDatabaseManagementServiceBuilder(dbDir.toPath()).impermanent().build();
         db = databases.database(DEFAULT_DATABASE_NAME);
         return new SpatialDatabaseService(new IndexManager((GraphDatabaseAPI) db, SecurityContext.AUTH_DISABLED));
     }

--- a/src/test/java/org/neo4j/gis/spatial/RTreeBulkInsertTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/RTreeBulkInsertTest.java
@@ -1582,7 +1582,7 @@ public class RTreeBulkInsertTest {
             FileUtils.deleteDirectory(storeDir);
         }
         FileUtils.forceMkdir(storeDir);
-        databases = new TestDatabaseManagementServiceBuilder(storeDir).impermanent().build();
+        databases = new TestDatabaseManagementServiceBuilder(storeDir.toPath()).impermanent().build();
         db = databases.database(DEFAULT_DATABASE_NAME);
     }
 

--- a/src/test/java/org/neo4j/gis/spatial/TestReadOnlyTransactions.java
+++ b/src/test/java/org/neo4j/gis/spatial/TestReadOnlyTransactions.java
@@ -13,6 +13,7 @@ import org.neo4j.test.TestDatabaseManagementServiceBuilder;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.configuration.GraphDatabaseSettings.DEFAULT_DATABASE_NAME;
@@ -28,7 +29,7 @@ import static org.neo4j.configuration.GraphDatabaseSettings.DEFAULT_DATABASE_NAM
 public class TestReadOnlyTransactions {
     private DatabaseManagementService databases;
     private GraphDatabaseService graph;
-    private static final File basePath = new File("target/var");
+    private static final Path basePath = new File("target/var").toPath();
     private static final String dbPrefix = "neo4j-db";
 
     private long storePrefix;
@@ -39,7 +40,7 @@ public class TestReadOnlyTransactions {
     @Before
     public void setUp() throws Exception {
         storePrefix++;
-        this.databases = new TestDatabaseManagementServiceBuilder(new File(basePath, dbPrefix + storePrefix)).impermanent().build();
+        this.databases = new TestDatabaseManagementServiceBuilder(basePath.resolve(dbPrefix + storePrefix)).impermanent().build();
         this.graph = databases.database(DEFAULT_DATABASE_NAME);
         buildDataModel();
     }
@@ -48,7 +49,7 @@ public class TestReadOnlyTransactions {
     public void tearDown() {
         databases.shutdown();
         try {
-            FileUtils.deleteRecursively(basePath);
+            FileUtils.deleteDirectory(basePath);
         } catch (IOException e) {
             System.out.println("Failed to delete database: " + e);
             e.printStackTrace();

--- a/src/test/java/org/neo4j/gis/spatial/TryWithResourceTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/TryWithResourceTest.java
@@ -19,7 +19,7 @@ public class TryWithResourceTest {
     @Test
     public void testSuppressedException() {
         try {
-            DatabaseManagementService databases = new TestDatabaseManagementServiceBuilder(new File("target/resource")).impermanent().build();
+            DatabaseManagementService databases = new TestDatabaseManagementServiceBuilder(new File("target/resource").toPath()).impermanent().build();
             GraphDatabaseService db = databases.database(DEFAULT_DATABASE_NAME);
             try (Transaction tx = db.beginTx()) {
                 Node n = tx.createNode();
@@ -40,7 +40,7 @@ public class TryWithResourceTest {
     @Test
     public void testSuppressedExceptionTopLevel() {
         try {
-            DatabaseManagementService databases = new TestDatabaseManagementServiceBuilder(new File("target/resource")).impermanent().build();
+            DatabaseManagementService databases = new TestDatabaseManagementServiceBuilder(new File("target/resource").toPath()).impermanent().build();
             GraphDatabaseService db = databases.database(DEFAULT_DATABASE_NAME);
             try (Transaction tx = db.beginTx()) {
                 Node n = tx.createNode();

--- a/src/test/java/org/neo4j/gis/spatial/index/LayerIndexTestBase.java
+++ b/src/test/java/org/neo4j/gis/spatial/index/LayerIndexTestBase.java
@@ -111,8 +111,8 @@ public abstract class LayerIndexTestBase {
     @Before
     public void setup() throws IOException {
         File baseDir = new File("target/layers");
-        FileUtils.deleteRecursively(baseDir);
-        databases = new TestDatabaseManagementServiceBuilder(baseDir).impermanent().build();
+        FileUtils.deleteDirectory(baseDir.toPath());
+        databases = new TestDatabaseManagementServiceBuilder(baseDir.toPath()).impermanent().build();
         graph = databases.database(DEFAULT_DATABASE_NAME);
         spatial = new SpatialDatabaseService(new IndexManager((GraphDatabaseAPI) graph, SecurityContext.AUTH_DISABLED));
     }

--- a/src/test/java/org/neo4j/gis/spatial/pipes/GeoPipesDocTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/pipes/GeoPipesDocTest.java
@@ -1033,7 +1033,7 @@ public class GeoPipesDocTest extends AbstractJavaDocTestBase {
 
     @BeforeClass
     public static void init() {
-        databases = new TestDatabaseManagementServiceBuilder(new File("target/docs")).impermanent().build();
+        databases = new TestDatabaseManagementServiceBuilder(new File("target/docs").toPath()).impermanent().build();
         db = databases.database(DEFAULT_DATABASE_NAME);
         try {
             load();

--- a/src/test/java/org/neo4j/gis/spatial/procedures/SpatialProceduresTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/procedures/SpatialProceduresTest.java
@@ -48,7 +48,7 @@ public class SpatialProceduresTest {
 
     @Before
     public void setUp() throws KernelException {
-        databases = new TestDatabaseManagementServiceBuilder(new File("target/procedures")).setConfig(GraphDatabaseSettings.procedure_unrestricted, List.of("spatial.*")).impermanent().build();
+        databases = new TestDatabaseManagementServiceBuilder(new File("target/procedures").toPath()).setConfig(GraphDatabaseSettings.procedure_unrestricted, List.of("spatial.*")).impermanent().build();
         db = databases.database(DEFAULT_DATABASE_NAME);
         registerProceduresAndFunctions(db, SpatialProcedures.class);
     }

--- a/src/test/java/org/neo4j/gis/spatial/rtree/RTreeTests.java
+++ b/src/test/java/org/neo4j/gis/spatial/rtree/RTreeTests.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.gis.spatial.rtree;
 
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.GeometryFactory;
 import org.geotools.data.neo4j.Neo4jFeatureBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.neo4j.dbms.api.DatabaseManagementService;
 import org.neo4j.gis.spatial.Constants;
 import org.neo4j.gis.spatial.encoders.SimplePointEncoder;
@@ -35,6 +35,7 @@ import org.opengis.feature.simple.SimpleFeatureType;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 
 import static org.neo4j.configuration.GraphDatabaseSettings.DEFAULT_DATABASE_NAME;
@@ -48,7 +49,7 @@ public class RTreeTests {
 
     @Before
     public void setup() {
-        databases = new TestDatabaseManagementServiceBuilder(new File("target/rtree")).impermanent().build();
+        databases = new TestDatabaseManagementServiceBuilder(Path.of("target", "rtree")).impermanent().build();
         db = databases.database(DEFAULT_DATABASE_NAME);
         try (Transaction tx = db.beginTx()) {
             this.rtree = new TestRTreeIndex(tx);


### PR DESCRIPTION
The change to Neo4j 4.2 was more subtle. Mostly only internal API's around the use of `Path` instead of `File`.
One change that could be noticed was the `IndexManager.IndexAccessMode` class.
In the 0.27.0 and 0.27.1 versions we used `OverridenAccessMode` to take the users existing access mode and simply add on the rights to create tokens and indexes. In 0.27.2 we instead use `RestrictedAccessMode` to restrict the users access right to the built in `AccessModel.Static.SCHEMA` and then boost to enable index and token writes. The difference is subtle and should only be possible to notice in Enterprise Edition.