### PR TITLE
Initial support for multiple OSM imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ This has meant that the spatial library needed a major refactoring to work with 
   and simply add on the rights to create tokens and indexes. In 0.27.2 we instead use `RestrictedAccessMode`
   to restrict the users access right to the built in `AccessModel.Static.SCHEMA` and then boost to enable
   index and token writes. The difference is subtle and should only be possible to notice in Enterprise Edition.
+* 0.28.0 tackles the ability to import multiple OSM files. The initial solution for Neo4j 4.x made use
+  of schema indexes keyed by the label and property. However, that means that all OSM imports would share
+  the same index. If they are completely disjointed data sets, this would not matter. But if you import
+  overlapping OSM files or different versions of the same file file, a mangled partial merger would result.
+  0.28.0 solves this by using different indexes, and keeping all imports completely separate.
+  The more complex problems of importing newer versions, and stitching together overlapping areas, are not
+  yet solved.
 
 Consequences of the port to Neo4j 4.x:
 
@@ -347,6 +354,7 @@ The Neo4j Spatial Plugin is available for inclusion in the server version of Neo
   * [v0.27.0 for Neo4j 4.0.3](https://github.com/neo4j-contrib/m2/blob/master/releases/org/neo4j/neo4j-spatial/0.27.0-neo4j-4.0.3/neo4j-spatial-0.27.0-neo4j-4.0.3-server-plugin.jar?raw=true)
   * [v0.27.1 for Neo4j 4.1.7](https://github.com/neo4j-contrib/m2/blob/master/releases/org/neo4j/neo4j-spatial/0.27.1-neo4j-4.1.7/neo4j-spatial-0.27.1-neo4j-4.1.7-server-plugin.jar?raw=true)
   * [v0.27.2 for Neo4j 4.2.3](https://github.com/neo4j-contrib/m2/blob/master/releases/org/neo4j/neo4j-spatial/0.27.2-neo4j-4.2.3/neo4j-spatial-0.27.2-neo4j-4.2.3-server-plugin.jar?raw=true)
+  * [v0.28.0 for Neo4j 4.2.3](https://github.com/neo4j-contrib/m2/blob/master/releases/org/neo4j/neo4j-spatial/0.28.0-neo4j-4.2.3/neo4j-spatial-0.28.0-neo4j-4.2.3-server-plugin.jar?raw=true)
 
 For versions up to 0.15-neo4j-2.3.4:
 
@@ -463,7 +471,7 @@ Add the following repositories and dependency to your project's pom.xml:
     <dependency>
         <groupId>org.neo4j</groupId>
         <artifactId>neo4j-spatial</artifactId>
-        <version>0.27.2-neo4j-4.2.3</version>
+        <version>0.28.0-neo4j-4.2.3</version>
     </dependency>
 ~~~
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-spatial</artifactId>
     <groupId>org.neo4j</groupId>
-    <version>0.27.2-neo4j-4.2.3</version>
+    <version>0.28.0-neo4j-4.2.3</version>
     <name>Neo4j - Spatial Components</name>
     <description>Spatial utilities and components for Neo4j</description>
     <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/src/main/java/org/neo4j/gis/spatial/Constants.java
+++ b/src/main/java/org/neo4j/gis/spatial/Constants.java
@@ -19,51 +19,54 @@
  */
 package org.neo4j.gis.spatial;
 
+import org.neo4j.graphdb.Label;
+
 /**
  * @author Davide Savazzi
  */
 public interface Constants {
 
-	// Node properties
-	
-	String PROP_BBOX = "bbox";
-	String PROP_LAYER = "layer";
-	String PROP_LAYERNODEEXTRAPROPS = "layerprops";
-	String PROP_CRS = "layercrs";
-	String PROP_CREATIONTIME = "ctime";
-	String PROP_GEOMENCODER = "geomencoder";
-	String PROP_INDEX_CLASS = "index_class";
-	String PROP_GEOMENCODER_CONFIG = "geomencoder_config";
-	String PROP_INDEX_CONFIG = "index_config";
+    // Node properties
+
+    String PROP_BBOX = "bbox";
+    String PROP_LAYER = "layer";
+    String PROP_LAYERNODEEXTRAPROPS = "layerprops";
+    String PROP_CRS = "layercrs";
+    String PROP_CREATIONTIME = "ctime";
+    String PROP_GEOMENCODER = "geomencoder";
+    String PROP_INDEX_CLASS = "index_class";
+    String PROP_GEOMENCODER_CONFIG = "geomencoder_config";
+    String PROP_INDEX_CONFIG = "index_config";
     String PROP_LAYER_CLASS = "layer_class";
 
-	String PROP_TYPE = "gtype";
-	String PROP_QUERY = "query";
-	String PROP_WKB = "wkb";
-	String PROP_WKT = "wkt";
-	String PROP_GEOM = "geometry";
-	
-	String[] RESERVED_PROPS = new String[] { 
-			PROP_BBOX,
-			PROP_LAYER, 
-			PROP_LAYERNODEEXTRAPROPS, 
-			PROP_CRS, 
-			PROP_CREATIONTIME, 
-			PROP_TYPE,
-			PROP_WKB,
-			PROP_WKT,
-			PROP_GEOM
-	};
-	
-	
-	// OpenGIS geometry type numbers 
-	
-	int GTYPE_GEOMETRY = 0;
-	int GTYPE_POINT = 1;
-	int GTYPE_LINESTRING = 2; 
-	int GTYPE_POLYGON = 3;
-	int GTYPE_MULTIPOINT = 4; 	
-	int GTYPE_MULTILINESTRING = 5; 
-	int GTYPE_MULTIPOLYGON = 6; 
-	
+    String PROP_TYPE = "gtype";
+    String PROP_QUERY = "query";
+    String PROP_WKB = "wkb";
+    String PROP_WKT = "wkt";
+    String PROP_GEOM = "geometry";
+
+    String[] RESERVED_PROPS = new String[]{
+            PROP_BBOX,
+            PROP_LAYER,
+            PROP_LAYERNODEEXTRAPROPS,
+            PROP_CRS,
+            PROP_CREATIONTIME,
+            PROP_TYPE,
+            PROP_WKB,
+            PROP_WKT,
+            PROP_GEOM
+    };
+
+    Label LABEL_LAYER = Label.label("SpatialLayer");
+
+    // OpenGIS geometry type numbers
+
+    int GTYPE_GEOMETRY = 0;
+    int GTYPE_POINT = 1;
+    int GTYPE_LINESTRING = 2;
+    int GTYPE_POLYGON = 3;
+    int GTYPE_MULTIPOINT = 4;
+    int GTYPE_MULTILINESTRING = 5;
+    int GTYPE_MULTIPOLYGON = 6;
+
 }

--- a/src/main/java/org/neo4j/gis/spatial/DefaultLayer.java
+++ b/src/main/java/org/neo4j/gis/spatial/DefaultLayer.java
@@ -259,7 +259,6 @@ public class DefaultLayer implements Constants, Layer, SpatialDataset {
     public void delete(Transaction tx, Listener monitor) {
         indexWriter.removeAll(tx, true, monitor);
         Node layerNode = getLayerNode(tx);
-        layerNode.getSingleRelationship(SpatialRelationshipTypes.LAYER, Direction.INCOMING).delete();
         layerNode.delete();
         layerNodeId = -1L;
     }

--- a/src/main/java/org/neo4j/gis/spatial/SpatialDatabaseService.java
+++ b/src/main/java/org/neo4j/gis/spatial/SpatialDatabaseService.java
@@ -19,9 +19,9 @@
  */
 package org.neo4j.gis.spatial;
 
-import org.locationtech.jts.geom.*;
 import org.geotools.referencing.crs.AbstractCRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.locationtech.jts.geom.*;
 import org.neo4j.gis.spatial.encoders.Configurable;
 import org.neo4j.gis.spatial.encoders.NativePointEncoder;
 import org.neo4j.gis.spatial.encoders.SimplePointEncoder;
@@ -32,7 +32,6 @@ import org.neo4j.gis.spatial.rtree.Listener;
 import org.neo4j.gis.spatial.utilities.LayerUtilities;
 import org.neo4j.gis.spatial.utilities.ReferenceNodes;
 import org.neo4j.graphdb.*;
-import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import java.util.ArrayList;
@@ -157,7 +156,7 @@ public class SpatialDatabaseService implements Constants {
     }
 
     public DefaultLayer getOrCreateDefaultLayer(Transaction tx, String name) {
-        return (DefaultLayer) getOrCreateLayer(tx, name, WKBGeometryEncoder.class, DefaultLayer.class, "");
+        return (DefaultLayer) getOrCreateLayer(tx, name, WKBGeometryEncoder.class, EditableLayerImpl.class, "");
     }
 
     public EditableLayer getOrCreateEditableLayer(Transaction tx, String name, String format, String propertyNameConfig) {
@@ -273,7 +272,7 @@ public class SpatialDatabaseService implements Constants {
     }
 
     public SimplePointLayer createSimplePointLayer(Transaction tx, String name) {
-        return createSimplePointLayer(tx, name, null);
+        return createSimplePointLayer(tx, name, (String[]) null);
     }
 
     public SimplePointLayer createSimplePointLayer(Transaction tx, String name, String xProperty, String yProperty) {
@@ -285,7 +284,7 @@ public class SpatialDatabaseService implements Constants {
     }
 
     public SimplePointLayer createNativePointLayer(Transaction tx, String name) {
-        return createNativePointLayer(tx, name, null);
+        return createNativePointLayer(tx, name, (String[]) null);
     }
 
     public SimplePointLayer createNativePointLayer(Transaction tx, String name, String locationProperty, String bboxProperty) {
@@ -353,7 +352,6 @@ public class SpatialDatabaseService implements Constants {
         layer.delete(tx, monitor);
     }
 
-    @SuppressWarnings("unchecked")
     public static int convertGeometryNameToType(String geometryName) {
         if (geometryName == null) return GTYPE_GEOMETRY;
         try {

--- a/src/main/java/org/neo4j/gis/spatial/osm/OSMImporter.java
+++ b/src/main/java/org/neo4j/gis/spatial/osm/OSMImporter.java
@@ -930,12 +930,10 @@ public class OSMImporter implements Constants {
             }
         }
 
-        private WrappedNode findNode(String name, WrappedNode parent, OSMRelation relType) {
-            for (Relationship relationship : parent.getRelationships(Direction.OUTGOING, relType)) {
-                Node node = relationship.getEndNode();
-                if (name.equals(node.getProperty("name"))) {
-                    return WrappedNode.fromNode(node);
-                }
+        private WrappedNode findNode(Label label, String name) {
+            Node node = tx.findNode(label, "name", name);
+            if (node != null) {
+                return WrappedNode.fromNode(node);
             }
             return null;
         }
@@ -1003,13 +1001,12 @@ public class OSMImporter implements Constants {
             return null;
         }
 
-        private WrappedNode getOrCreateNode(Label label, String name, String type, WrappedNode parent, OSMRelation relType) {
-            WrappedNode node = findNode(name, parent, relType);
+        private WrappedNode getOrCreateNode(Label label, String name, String type) {
+            WrappedNode node = findNode(label, name);
             if (node == null) {
                 Node n = tx.createNode(label);
                 n.setProperty("name", name);
                 n.setProperty("type", type);
-                parent.inner.createRelationshipTo(n, relType);
                 node = checkTx(WrappedNode.fromNode(n));
             }
             return node;
@@ -1018,8 +1015,7 @@ public class OSMImporter implements Constants {
         @Override
         protected WrappedNode getOrCreateOSMDataset(String name) {
             if (osm_dataset == null) {
-                Node osm_root = ReferenceNodes.getReferenceNode(tx, "osm_root");
-                osm_dataset = getOrCreateNode(LABEL_DATASET, name, "osm", WrappedNode.fromNode(osm_root), OSMRelation.OSM);
+                osm_dataset = getOrCreateNode(LABEL_DATASET, name, "osm");
             }
             return osm_dataset;
         }

--- a/src/main/java/org/neo4j/gis/spatial/utilities/LayerUtilities.java
+++ b/src/main/java/org/neo4j/gis/spatial/utilities/LayerUtilities.java
@@ -27,7 +27,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 
 /**
- * Utilities for creating layersfrom nodes.
+ * Utilities for creating layers from nodes.
  */
 public class LayerUtilities implements Constants {
 
@@ -72,6 +72,7 @@ public class LayerUtilities implements Constants {
                 indexClass = LayerRTreeIndex.class;
             }
             Node layerNode = tx.createNode();
+            layerNode.addLabel(LABEL_LAYER);
             layerNode.setProperty(PROP_LAYER, name);
             layerNode.setProperty(PROP_CREATIONTIME, System.currentTimeMillis());
             layerNode.setProperty(PROP_GEOMENCODER, geometryEncoderClass.getCanonicalName());

--- a/src/test/java/org/neo4j/gis/spatial/Neo4jSpatialDataStoreTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/Neo4jSpatialDataStoreTest.java
@@ -35,7 +35,7 @@ public class Neo4jSpatialDataStoreTest {
     public GraphDatabaseService graph;
 
     @Before
-    public void setup() throws IOException, XMLStreamException {
+    public void setup() throws Exception {
         this.databases = new TestDatabaseManagementServiceBuilder(Path.of("target", "test")).impermanent().build();
         this.graph = databases.database(DEFAULT_DATABASE_NAME);
         OSMImporter importer = new OSMImporter("map", new ConsoleListener());

--- a/src/test/java/org/neo4j/gis/spatial/OsmAnalysisTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/OsmAnalysisTest.java
@@ -29,6 +29,7 @@ import org.neo4j.dbms.api.DatabaseManagementService;
 import org.neo4j.gis.spatial.filter.SearchRecords;
 import org.neo4j.gis.spatial.index.IndexManager;
 import org.neo4j.gis.spatial.osm.OSMDataset;
+import org.neo4j.gis.spatial.osm.OSMImporter;
 import org.neo4j.gis.spatial.osm.OSMLayer;
 import org.neo4j.gis.spatial.osm.OSMRelation;
 import org.neo4j.gis.spatial.rtree.Envelope;
@@ -272,8 +273,7 @@ public class OsmAnalysisTest extends TestOSMImport {
         SortedMap<String, Layer> layers;
         ReferencedEnvelope bbox;
         try (Transaction tx = graphDb().beginTx()) {
-            Node osmRoot = ReferenceNodes.getReferenceNode(tx, "osm_root");
-            Node osmImport = osmRoot.getSingleRelationship(OSMRelation.OSM, Direction.OUTGOING).getEndNode();
+            Node osmImport = tx.findNode(OSMImporter.LABEL_DATASET, "name", osm);
             Node usersNode = osmImport.getSingleRelationship(OSMRelation.USERS, Direction.OUTGOING).getEndNode();
 
             Map<String, User> userIndex = collectUserChangesetData(usersNode);

--- a/src/test/java/org/neo4j/gis/spatial/procedures/SpatialProceduresTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/procedures/SpatialProceduresTest.java
@@ -929,6 +929,22 @@ public class SpatialProceduresTest {
         testCallCount(db, "CALL spatial.layers()", null, 1);
     }
 
+    @Test
+    public void import_osm_twice_should_pass_with_different_layers() {
+        execute("CALL spatial.addLayer('geom1','OSM','')");
+        execute("CALL spatial.addLayer('geom2','OSM','')");
+
+        testCountQuery("importOSM", "CALL spatial.importOSMToLayer('geom1','map.osm')", 55, "count", null);
+        testCallCount(db, "CALL spatial.layers()", null, 2);
+        testCallCount(db, "CALL spatial.withinDistance('geom1',{lon:6.3740429666,lat:50.93676351666},10000)", null, 217);
+        testCallCount(db, "CALL spatial.withinDistance('geom2',{lon:6.3740429666,lat:50.93676351666},10000)", null, 0);
+
+        testCountQuery("importOSM", "CALL spatial.importOSMToLayer('geom2','map.osm')", 55, "count", null);
+        testCallCount(db, "CALL spatial.layers()", null, 2);
+        testCallCount(db, "CALL spatial.withinDistance('geom1',{lon:6.3740429666,lat:50.93676351666},10000)", null, 217);
+        testCallCount(db, "CALL spatial.withinDistance('geom2',{lon:6.3740429666,lat:50.93676351666},10000)", null, 217);
+    }
+
     @Ignore
     public void import_cracow_to_layer() {
         execute("CALL spatial.addLayer('geom','OSM','')");


### PR DESCRIPTION
Version 0.28 begins work on trying to deal work multiple OSM imports. For this release, we disallow importing the same OSM file twice, unless you specify two separate layers, and we also ensure that the indexes are not mixed up between the layers, something that was the case in all previous releases.

To achieve this, two main changes were made:

* Use unique labels for indexing within multiple OSM layers.
  Essentially when adding nodes of a particular label, we also add a label with a unique name for indexing purposes.
  The unique name is made of the original name plus a hex suffix made of the MD5 hash of the layer name.
   For example, the layer `geom1` will have an MD5 hash of its name `9ECE5459EA0D46FC556E5E3F454A0795`.
  Then when adding an OSM node we label the node with both:
    
    * OSMNode
    * OSMNode_9ECE5459EA0D46FC556E5E3F454A0795

* Remove use of old reference nodes, reducing deadlocks. 
  This change is not backwards compatible, as the spatial model is different. Layers created in earlier versions would not be readable in this one. 
  To protect against that we throw exceptions on all SpatialDatabaseService. layer finding methods, if they detect the old format. The exception requests that the database be upgraded. 
  This can be done in the Java API with the upgradeFromOldModel method, or via procedures using `spatial.upgrade`.


