### PR TITLE
Port Spatial 0.28 to Neo4j 4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ The Neo4j Spatial Plugin is available for inclusion in the server version of Neo
   * [v0.27.1 for Neo4j 4.1.7](https://github.com/neo4j-contrib/m2/blob/master/releases/org/neo4j/neo4j-spatial/0.27.1-neo4j-4.1.7/neo4j-spatial-0.27.1-neo4j-4.1.7-server-plugin.jar?raw=true)
   * [v0.27.2 for Neo4j 4.2.3](https://github.com/neo4j-contrib/m2/blob/master/releases/org/neo4j/neo4j-spatial/0.27.2-neo4j-4.2.3/neo4j-spatial-0.27.2-neo4j-4.2.3-server-plugin.jar?raw=true)
   * [v0.28.0 for Neo4j 4.2.3](https://github.com/neo4j-contrib/m2/blob/master/releases/org/neo4j/neo4j-spatial/0.28.0-neo4j-4.2.3/neo4j-spatial-0.28.0-neo4j-4.2.3-server-plugin.jar?raw=true)
+  * [v0.28.0 for Neo4j 4.3.10](https://github.com/neo4j-contrib/m2/blob/master/releases/org/neo4j/neo4j-spatial/0.28.0-neo4j-4.3.10/neo4j-spatial-0.28.0-neo4j-4.3.10-server-plugin.jar?raw=true)
 
 For versions up to 0.15-neo4j-2.3.4:
 
@@ -471,7 +472,7 @@ Add the following repositories and dependency to your project's pom.xml:
     <dependency>
         <groupId>org.neo4j</groupId>
         <artifactId>neo4j-spatial</artifactId>
-        <version>0.28.0-neo4j-4.2.3</version>
+        <version>0.28.0-neo4j-4.3.10</version>
     </dependency>
 ~~~
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ This has meant that the spatial library needed a major refactoring to work with 
   0.28.0 solves this by using different indexes, and keeping all imports completely separate.
   The more complex problems of importing newer versions, and stitching together overlapping areas, are not
   yet solved.
+* Neo4j 4.3 has an issue with leaking RelationshipTraversalCursor, and we needed to do some workarounds to
+  avoid this issue, usually by exhausting the iterator, which can have a higher performance cost in some cases.
+  Version 0.28.1 includes this fix.
 
 Consequences of the port to Neo4j 4.x:
 
@@ -355,7 +358,7 @@ The Neo4j Spatial Plugin is available for inclusion in the server version of Neo
   * [v0.27.1 for Neo4j 4.1.7](https://github.com/neo4j-contrib/m2/blob/master/releases/org/neo4j/neo4j-spatial/0.27.1-neo4j-4.1.7/neo4j-spatial-0.27.1-neo4j-4.1.7-server-plugin.jar?raw=true)
   * [v0.27.2 for Neo4j 4.2.3](https://github.com/neo4j-contrib/m2/blob/master/releases/org/neo4j/neo4j-spatial/0.27.2-neo4j-4.2.3/neo4j-spatial-0.27.2-neo4j-4.2.3-server-plugin.jar?raw=true)
   * [v0.28.0 for Neo4j 4.2.3](https://github.com/neo4j-contrib/m2/blob/master/releases/org/neo4j/neo4j-spatial/0.28.0-neo4j-4.2.3/neo4j-spatial-0.28.0-neo4j-4.2.3-server-plugin.jar?raw=true)
-  * [v0.28.0 for Neo4j 4.3.10](https://github.com/neo4j-contrib/m2/blob/master/releases/org/neo4j/neo4j-spatial/0.28.0-neo4j-4.3.10/neo4j-spatial-0.28.0-neo4j-4.3.10-server-plugin.jar?raw=true)
+  * [v0.28.1 for Neo4j 4.3.10](https://github.com/neo4j-contrib/m2/blob/master/releases/org/neo4j/neo4j-spatial/0.28.1-neo4j-4.3.10/neo4j-spatial-0.28.1-neo4j-4.3.10-server-plugin.jar?raw=true)
 
 For versions up to 0.15-neo4j-2.3.4:
 
@@ -472,7 +475,7 @@ Add the following repositories and dependency to your project's pom.xml:
     <dependency>
         <groupId>org.neo4j</groupId>
         <artifactId>neo4j-spatial</artifactId>
-        <version>0.28.0-neo4j-4.3.10</version>
+        <version>0.28.1-neo4j-4.3.10</version>
     </dependency>
 ~~~
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <properties>
-        <neo4j.version>4.3.2</neo4j.version>
+        <neo4j.version>4.3.10</neo4j.version>
         <lucene.version>8.2.0</lucene.version>
         <!-- make sure lucene version is the same as the one the current neo4j depends on -->
         <neo4j.java.version>11</neo4j.java.version>
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-spatial</artifactId>
     <groupId>org.neo4j</groupId>
-    <version>0.28.0-neo4j-4.3.2</version>
+    <version>0.28.0-neo4j-4.3.10</version>
     <name>Neo4j - Spatial Components</name>
     <description>Spatial utilities and components for Neo4j</description>
     <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <properties>
-        <neo4j.version>4.2.3</neo4j.version>
+        <neo4j.version>4.3.2</neo4j.version>
         <lucene.version>8.2.0</lucene.version>
         <!-- make sure lucene version is the same as the one the current neo4j depends on -->
         <neo4j.java.version>11</neo4j.java.version>
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-spatial</artifactId>
     <groupId>org.neo4j</groupId>
-    <version>0.28.0-neo4j-4.2.3</version>
+    <version>0.28.0-neo4j-4.3.2</version>
     <name>Neo4j - Spatial Components</name>
     <description>Spatial utilities and components for Neo4j</description>
     <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-spatial</artifactId>
     <groupId>org.neo4j</groupId>
-    <version>0.28.0-neo4j-4.3.10</version>
+    <version>0.28.1-neo4j-4.3.10</version>
     <name>Neo4j - Spatial Components</name>
     <description>Spatial utilities and components for Neo4j</description>
     <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/src/main/java/org/neo4j/gis/spatial/osm/OSMDataset.java
+++ b/src/main/java/org/neo4j/gis/spatial/osm/OSMDataset.java
@@ -23,6 +23,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.neo4j.gis.spatial.*;
+import org.neo4j.gis.spatial.utilities.RelationshipTraversal;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -144,8 +145,7 @@ public class OSMDataset implements SpatialDataset, Iterator<OSMDataset.Way> {
                 .relationships(OSMRelation.CHANGESET, Direction.OUTGOING)
                 .relationships(OSMRelation.USER, Direction.OUTGOING)
                 .evaluator(Evaluators.includeWhereLastRelationshipTypeIs(OSMRelation.USER));
-        Iterator<Node> results = td.traverse(nodeWayOrChangeset).nodes().iterator();
-        return results.hasNext() ? results.next() : null;
+        return RelationshipTraversal.getFirstNode(td.traverse(nodeWayOrChangeset).nodes());
     }
 
     public Way getWayFromId(Transaction tx, long id) {
@@ -161,8 +161,8 @@ public class OSMDataset implements SpatialDataset, Iterator<OSMDataset.Way> {
                 .relationships(OSMRelation.GEOM, Direction.INCOMING)
                 .evaluator(path -> path.endNode().hasProperty("way_osm_id") ? Evaluation.INCLUDE_AND_PRUNE
                         : Evaluation.EXCLUDE_AND_CONTINUE);
-        Iterator<Node> results = td.traverse(osmNodeOrWayNodeOrGeomNode).nodes().iterator();
-        return results.hasNext() ? new Way(results.next()) : null;
+        Node node = RelationshipTraversal.getFirstNode(td.traverse(osmNodeOrWayNodeOrGeomNode).nodes());
+        return node != null ? new Way(node) : null;
     }
 
     public class OSMNode {

--- a/src/main/java/org/neo4j/gis/spatial/pipes/impl/AbstractPipe.java
+++ b/src/main/java/org/neo4j/gis/spatial/pipes/impl/AbstractPipe.java
@@ -45,6 +45,9 @@ public abstract class AbstractPipe<S, E> implements Pipe<S, E> {
         if (this.starts instanceof Pipe) {
             ((Pipe) this.starts).reset();
         }
+        if (this.starts instanceof LastElementIterator) {
+            ((LastElementIterator) this.starts).reset();
+        }
         this.nextEnd = null;
         this.currentEnd = null;
         this.available = false;

--- a/src/main/java/org/neo4j/gis/spatial/pipes/impl/LastElementIterator.java
+++ b/src/main/java/org/neo4j/gis/spatial/pipes/impl/LastElementIterator.java
@@ -1,5 +1,7 @@
 package org.neo4j.gis.spatial.pipes.impl;
 
+import org.neo4j.gis.spatial.utilities.RelationshipTraversal;
+
 import java.util.Iterator;
 
 public class LastElementIterator<T> implements Iterator<T> {
@@ -25,5 +27,15 @@ public class LastElementIterator<T> implements Iterator<T> {
 
     public T lastElement() {
         return lastElement;
+    }
+
+    /**
+     * Work around bug in Neo4j 4.3 with leaked RelationshipTraversalCursor
+     */
+    public void reset() {
+        // TODO: rather try get deeper into the underlying index and close resources instead of exhausting the iterator
+        // The challenge is that there are many sources, all of which need to be made closable, and that is very hard
+        // to achieve in a generic way without a full-stack code change.
+        RelationshipTraversal.exhaustIterator(source);
     }
 }

--- a/src/main/java/org/neo4j/gis/spatial/pipes/impl/Pipeline.java
+++ b/src/main/java/org/neo4j/gis/spatial/pipes/impl/Pipeline.java
@@ -127,6 +127,7 @@ public class Pipeline<S, E> implements Pipe<S, E> {
     }
 
     public void reset() {
+        this.startPipe.reset(); // Clear incoming state to avoid bug in Neo4j 4.3 with leaked RelationshipTraversalCursor
         this.endPipe.reset();
     }
 

--- a/src/main/java/org/neo4j/gis/spatial/utilities/RelationshipTraversal.java
+++ b/src/main/java/org/neo4j/gis/spatial/utilities/RelationshipTraversal.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2010-2022 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j Spatial.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.gis.spatial.utilities;
+
+import org.neo4j.graphdb.*;
+
+import java.util.Iterator;
+
+/**
+ * Neo4j 4.3 introduced some bugs around closing RelationshipTraversalCursor.
+ * This class provides alternative implementations of suspicious methods to work around that issue.
+ */
+public class RelationshipTraversal {
+    /**
+     * Normally just calling iterator.next() once should work, but the bug in Neo4j 4.3 results in leaked cursors
+     * if this iterator comes from the traversal framework, so this code exhausts the traverser and returns the first
+     * node found. For cases where many results could be found, this is expensive. Try to use only when one or few results
+     * are likely.
+     */
+    public static Node getFirstNode(Iterable<Node> nodes) {
+        Node found = null;
+        for (Node node : nodes) {
+            if (found == null) found = node;
+        }
+        return found;
+    }
+
+    /**
+     * Some code has facilities for closing resource at a high level, but the underlying resources are only
+     * Iterators, with no access to the original sources and no way to close the resources properly.
+     * So to avoid the Neo4j 4.3 bug with leaked RelationshipTraversalCursor, we need to exhaust the iterator.
+     */
+    public static void exhaustIterator(Iterator source) {
+        while (source.hasNext()) {
+            source.next();
+        }
+    }
+}

--- a/src/test/java/org/neo4j/gis/spatial/Neo4jTestCase.java
+++ b/src/test/java/org/neo4j/gis/spatial/Neo4jTestCase.java
@@ -23,6 +23,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.neo4j.configuration.Config;
+import org.neo4j.configuration.GraphDatabaseInternalSettings;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.dbms.api.DatabaseManagementService;
 import org.neo4j.gis.spatial.procedures.SpatialProcedures;
@@ -57,6 +58,7 @@ public abstract class Neo4jTestCase {
         //NORMAL_CONFIG.put( GraphDatabaseSettings.strings_mapped_memory_size.name(), "200M" );
         //NORMAL_CONFIG.put( GraphDatabaseSettings.arrays_mapped_memory_size.name(), "0M" );
         NORMAL_CONFIG.put(GraphDatabaseSettings.pagecache_memory.name(), "200M");
+        NORMAL_CONFIG.put(GraphDatabaseInternalSettings.trace_cursors.name(), "true");
     }
 
     static final Map<String, String> LARGE_CONFIG = new HashMap<>();

--- a/src/test/java/org/neo4j/gis/spatial/Neo4jTestCase.java
+++ b/src/test/java/org/neo4j/gis/spatial/Neo4jTestCase.java
@@ -25,7 +25,6 @@ import org.junit.Rule;
 import org.neo4j.configuration.Config;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.dbms.api.DatabaseManagementService;
-import org.neo4j.dbms.api.DatabaseManagementServiceBuilder;
 import org.neo4j.gis.spatial.procedures.SpatialProcedures;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.io.fs.FileUtils;
@@ -33,6 +32,7 @@ import org.neo4j.io.layout.DatabaseLayout;
 import org.neo4j.io.layout.Neo4jLayout;
 import org.neo4j.kernel.api.procedure.GlobalProcedures;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.test.TestDatabaseManagementServiceBuilder;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
 import java.io.File;
@@ -100,7 +100,7 @@ public abstract class Neo4jTestCase {
         if (largeMode != null && largeMode.equalsIgnoreCase("true")) {
             config = LARGE_CONFIG;
         }
-        databases = new DatabaseManagementServiceBuilder(getDbPath()).setConfigRaw(config).build();
+        databases = new TestDatabaseManagementServiceBuilder(getDbPath()).setConfigRaw(config).build();
         graphDb = databases.database(DEFAULT_DATABASE_NAME);
         ((GraphDatabaseAPI) graphDb).getDependencyResolver().resolveDependency(GlobalProcedures.class).registerProcedure(SpatialProcedures.class);
     }

--- a/src/test/java/org/neo4j/gis/spatial/RTreeBulkInsertTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/RTreeBulkInsertTest.java
@@ -1,12 +1,13 @@
 package org.neo4j.gis.spatial;
 
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.Geometry;
 import org.apache.commons.io.FileUtils;
 import org.geotools.data.neo4j.Neo4jFeatureBuilder;
 import org.geotools.referencing.crs.DefaultEngineeringCRS;
 import org.junit.*;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
 import org.neo4j.dbms.api.DatabaseManagementService;
+import org.neo4j.dbms.api.DatabaseManagementServiceBuilder;
 import org.neo4j.gis.spatial.encoders.SimplePointEncoder;
 import org.neo4j.gis.spatial.index.*;
 import org.neo4j.gis.spatial.pipes.GeoPipeFlow;
@@ -16,7 +17,6 @@ import org.neo4j.gis.spatial.rtree.*;
 import org.neo4j.graphdb.*;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
-import org.neo4j.test.TestDatabaseManagementServiceBuilder;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
@@ -1582,7 +1582,7 @@ public class RTreeBulkInsertTest {
             FileUtils.deleteDirectory(storeDir);
         }
         FileUtils.forceMkdir(storeDir);
-        databases = new TestDatabaseManagementServiceBuilder(storeDir.toPath()).impermanent().build();
+        databases = new DatabaseManagementServiceBuilder(storeDir.toPath()).build();
         db = databases.database(DEFAULT_DATABASE_NAME);
     }
 

--- a/src/test/java/org/neo4j/gis/spatial/TestOSMImport.java
+++ b/src/test/java/org/neo4j/gis/spatial/TestOSMImport.java
@@ -134,9 +134,10 @@ public class TestOSMImport extends Neo4jTestCase {
         Way way = null;
         int count = 0;
         for (Way wayNode : osm.getWays(tx)) {
-            way = wayNode;
-            if (count++ > 100)
-                break;
+            // Do not `break` from the loop or experience the RelationshipTraversalCursor leak bug in Neo4j 4.3
+            if (count++ <= 100) {
+                way = wayNode;
+            }
         }
         assertNotNull("Should be at least one way", way);
         Envelope bbox = way.getEnvelope();

--- a/src/test/java/org/neo4j/gis/spatial/TestsForDocs.java
+++ b/src/test/java/org/neo4j/gis/spatial/TestsForDocs.java
@@ -19,14 +19,14 @@
  */
 package org.neo4j.gis.spatial;
 
-import org.locationtech.jts.geom.Envelope;
-import org.locationtech.jts.geom.Geometry;
 import org.geotools.data.DataStore;
 import org.geotools.data.neo4j.Neo4jSpatialDataStore;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
 import org.neo4j.dbms.api.DatabaseManagementService;
 import org.neo4j.dbms.api.DatabaseManagementServiceBuilder;
 import org.neo4j.gis.spatial.index.IndexManager;
@@ -44,9 +44,9 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 
@@ -67,7 +67,7 @@ public class TestsForDocs {
 
     @Before
     public void setUp() throws Exception {
-        this.databases = new DatabaseManagementServiceBuilder(new File("target/docs-db")).build();
+        this.databases = new DatabaseManagementServiceBuilder(Path.of("target", "docs-db")).build();
         this.graphDb = databases.database(DEFAULT_DATABASE_NAME);
         try (Transaction tx = this.graphDb.beginTx()) {
             tx.getAllRelationships().forEach(Relationship::delete);
@@ -128,10 +128,9 @@ public class TestsForDocs {
                 mostCount = waysFound.get(wayId);
             }
         }
-        System.out.println("Found " + waysFound.size() + " ways overlapping '" + way.toString() + "'");
+        System.out.println("Found " + waysFound.size() + " ways overlapping '" + way + "'");
         for (long wayId : waysFound.keySet()) {
-            System.out.println("\t" + wayId + ":\t" + waysFound.get(wayId) +
-                    ((wayId == way.getNode().getId()) ? "\t(original way)" : ""));
+            System.out.println("\t" + wayId + ":\t" + waysFound.get(wayId) + ((wayId == way.getNode().getId()) ? "\t(original way)" : ""));
         }
         assertTrue("Start way should be most found way", way.equals(osm.getWayFromId(tx, mostCommon)));
     }

--- a/src/test/java/org/neo4j/gis/spatial/pipes/GeoPipesDocTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/pipes/GeoPipesDocTest.java
@@ -351,6 +351,7 @@ public class GeoPipesDocTest extends AbstractJavaDocTestBase {
 
         assertEquals("POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))",
                 pipeline.next().getProperties().get("WellKnownText"));
+        pipeline.reset();
     }
 
     /**
@@ -378,6 +379,7 @@ public class GeoPipesDocTest extends AbstractJavaDocTestBase {
         assertEquals(
                 "POLYGON ((0 0, 0 5, 0 10, 5 10, 10 10, 10 5, 10 0, 5 0, 0 0))",
                 pipeline.next().getProperties().get("WellKnownText"));
+        pipeline.reset();
     }
 
     @Test
@@ -770,6 +772,7 @@ public class GeoPipesDocTest extends AbstractJavaDocTestBase {
                 .createWellKnownText();
 
         assertEquals("POINT (12 26)", pipeline.next().getProperty(tx, "WellKnownText"));
+        pipeline.reset();
     }
 
     /**
@@ -798,6 +801,7 @@ public class GeoPipesDocTest extends AbstractJavaDocTestBase {
                 .createWellKnownText();
 
         assertEquals("POINT (23 34)", pipeline.next().getProperty(tx, "WellKnownText"));
+        pipeline.reset();
     }
 
     /**

--- a/src/test/java/org/neo4j/gis/spatial/pipes/GeoPipesPerformanceTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/pipes/GeoPipesPerformanceTest.java
@@ -156,6 +156,7 @@ public class GeoPipesPerformanceTest extends Neo4jTestCase {
                     // " records");
                     count++;
                 }
+                flowList.reset();
                 long time = System.currentTimeMillis();
                 totals.add(new TimeRecord(chunk, (int) (time - prevTime), count));
                 prevTime = time;


### PR DESCRIPTION
There were many issues with leaking RelationshipTraversalCursor in Neo4j 4.3, and this requires a few workaround.