### PR TITLE
Make spatial query procedures read only

### DIFF
--- a/src/main/java/org/neo4j/gis/spatial/EditableLayer.java
+++ b/src/main/java/org/neo4j/gis/spatial/EditableLayer.java
@@ -63,5 +63,5 @@ public interface EditableLayer extends Layer {
 	/**
 	 * Do any cleanup or final calculation required by the layer implementation.
 	 */
-	void close(Transaction tx);
+	void finalizeTransaction(Transaction tx);
 }

--- a/src/main/java/org/neo4j/gis/spatial/EditableLayer.java
+++ b/src/main/java/org/neo4j/gis/spatial/EditableLayer.java
@@ -59,4 +59,9 @@ public interface EditableLayer extends Layer {
 	void setCoordinateReferenceSystem(Transaction tx, CoordinateReferenceSystem coordinateReferenceSystem);
 
 	void removeFromIndex(Transaction tx, String geomNodeId);
+
+	/**
+	 * Do any cleanup or final calculation required by the layer implementation.
+	 */
+	void close(Transaction tx);
 }

--- a/src/main/java/org/neo4j/gis/spatial/EditableLayerImpl.java
+++ b/src/main/java/org/neo4j/gis/spatial/EditableLayerImpl.java
@@ -81,4 +81,9 @@ public class EditableLayerImpl extends DefaultLayer implements EditableLayer {
 	public String getSignature() {
 		return "Editable" + super.getSignature();
 	}
+
+	@Override
+	public void close(Transaction tx) {
+		getIndex().close(tx);
+	}
 }

--- a/src/main/java/org/neo4j/gis/spatial/EditableLayerImpl.java
+++ b/src/main/java/org/neo4j/gis/spatial/EditableLayerImpl.java
@@ -83,7 +83,7 @@ public class EditableLayerImpl extends DefaultLayer implements EditableLayer {
 	}
 
 	@Override
-	public void close(Transaction tx) {
-		getIndex().close(tx);
+	public void finalizeTransaction(Transaction tx) {
+		getIndex().finalizeTransaction(tx);
 	}
 }

--- a/src/main/java/org/neo4j/gis/spatial/ShapefileImporter.java
+++ b/src/main/java/org/neo4j/gis/spatial/ShapefileImporter.java
@@ -221,7 +221,7 @@ public class ShapefileImporter implements Constants {
 			}
 		}
 		try (Transaction tx = database.beginTx()) {
-			layer.close(tx);
+			layer.finalizeTransaction(tx);
 			tx.commit();
 		}
 

--- a/src/main/java/org/neo4j/gis/spatial/ShapefileImporter.java
+++ b/src/main/java/org/neo4j/gis/spatial/ShapefileImporter.java
@@ -220,6 +220,10 @@ public class ShapefileImporter implements Constants {
 				}
 			}
 		}
+		try (Transaction tx = database.beginTx()) {
+			layer.close(tx);
+			tx.commit();
+		}
 
 		long stopTime = System.currentTimeMillis();
 		log("info | elapsed time in seconds: " + (1.0 * (stopTime - startTime) / 1000));

--- a/src/main/java/org/neo4j/gis/spatial/index/SpatialIndexReader.java
+++ b/src/main/java/org/neo4j/gis/spatial/index/SpatialIndexReader.java
@@ -47,4 +47,7 @@ public interface SpatialIndexReader {
 	void addMonitor(TreeMonitor monitor);
 
 	void configure(Map<String, Object> config);
+
+	default void close(Transaction tx) {
+	}
 }

--- a/src/main/java/org/neo4j/gis/spatial/index/SpatialIndexReader.java
+++ b/src/main/java/org/neo4j/gis/spatial/index/SpatialIndexReader.java
@@ -48,6 +48,6 @@ public interface SpatialIndexReader {
 
 	void configure(Map<String, Object> config);
 
-	default void close(Transaction tx) {
+	default void finalizeTransaction(Transaction tx) {
 	}
 }

--- a/src/main/java/org/neo4j/gis/spatial/osm/OSMImporter.java
+++ b/src/main/java/org/neo4j/gis/spatial/osm/OSMImporter.java
@@ -329,7 +329,7 @@ public class OSMImporter implements Constants {
 					}
 				} // TODO ask charset to user?
 			}
-			layer.close(tx);
+			layer.finalizeTransaction(tx);
 			tx.commit();
 		} finally {
 			endProgressMonitor();

--- a/src/main/java/org/neo4j/gis/spatial/osm/OSMImporter.java
+++ b/src/main/java/org/neo4j/gis/spatial/osm/OSMImporter.java
@@ -329,6 +329,7 @@ public class OSMImporter implements Constants {
 					}
 				} // TODO ask charset to user?
 			}
+			layer.close(tx);
 			tx.commit();
 		} finally {
 			endProgressMonitor();

--- a/src/main/java/org/neo4j/gis/spatial/procedures/SpatialProcedures.java
+++ b/src/main/java/org/neo4j/gis/spatial/procedures/SpatialProcedures.java
@@ -555,7 +555,7 @@ public class SpatialProcedures extends SpatialApiBase {
 	public Stream<NodeResult> addNodeToLayer(@Name("layerName") String name, @Name("node") Node node) {
 		EditableLayer layer = getEditableLayerOrThrow(tx, spatial(), name);
 		Node geomNode = layer.add(tx, node).getGeomNode();
-		layer.close(tx);
+		layer.finalizeTransaction(tx);
 		return streamNode(geomNode);
 	}
 
@@ -564,7 +564,7 @@ public class SpatialProcedures extends SpatialApiBase {
 	public Stream<CountResult> addNodesToLayer(@Name("layerName") String name, @Name("nodes") List<Node> nodes) {
 		EditableLayer layer = getEditableLayerOrThrow(tx, spatial(), name);
 		int count = layer.addAll(tx, nodes);
-		layer.close(tx);
+		layer.finalizeTransaction(tx);
 		return Stream.of(new CountResult(count));
 	}
 
@@ -573,7 +573,7 @@ public class SpatialProcedures extends SpatialApiBase {
 	public Stream<NodeResult> addNodeIdToLayer(@Name("layerName") String name, @Name("nodeId") String nodeId) {
 		EditableLayer layer = getEditableLayerOrThrow(tx, spatial(), name);
 		Node geomNode = layer.add(tx, tx.getNodeByElementId(nodeId)).getGeomNode();
-		layer.close(tx);
+		layer.finalizeTransaction(tx);
 		return streamNode(geomNode);
 	}
 
@@ -584,7 +584,7 @@ public class SpatialProcedures extends SpatialApiBase {
 		EditableLayer layer = getEditableLayerOrThrow(tx, spatial(), name);
 		List<Node> nodes = nodeIds.stream().map(id -> tx.getNodeByElementId(id)).collect(Collectors.toList());
 		int count = layer.addAll(tx, nodes);
-		layer.close(tx);
+		layer.finalizeTransaction(tx);
 		return Stream.of(new CountResult(count));
 	}
 
@@ -593,7 +593,7 @@ public class SpatialProcedures extends SpatialApiBase {
 	public Stream<NodeIdResult> removeNodeFromLayer(@Name("layerName") String name, @Name("node") Node node) {
 		EditableLayer layer = getEditableLayerOrThrow(tx, spatial(), name);
 		layer.removeFromIndex(tx, node.getElementId());
-		layer.close(tx);
+		layer.finalizeTransaction(tx);
 		return streamNode(node.getElementId());
 	}
 
@@ -607,7 +607,7 @@ public class SpatialProcedures extends SpatialApiBase {
 			layer.removeFromIndex(tx, node.getElementId());
 		}
 		int after = layer.getIndex().count(tx);
-		layer.close(tx);
+		layer.finalizeTransaction(tx);
 		return Stream.of(new CountResult(before - after));
 	}
 
@@ -616,7 +616,7 @@ public class SpatialProcedures extends SpatialApiBase {
 	public Stream<NodeIdResult> removeNodeFromLayer(@Name("layerName") String name, @Name("nodeId") String nodeId) {
 		EditableLayer layer = getEditableLayerOrThrow(tx, spatial(), name);
 		layer.removeFromIndex(tx, nodeId);
-		layer.close(tx);
+		layer.finalizeTransaction(tx);
 		return streamNode(nodeId);
 	}
 
@@ -631,7 +631,7 @@ public class SpatialProcedures extends SpatialApiBase {
 			layer.removeFromIndex(tx, nodeId);
 		}
 		int after = layer.getIndex().count(tx);
-		layer.close(tx);
+		layer.finalizeTransaction(tx);
 		return Stream.of(new CountResult(before - after));
 	}
 
@@ -642,7 +642,7 @@ public class SpatialProcedures extends SpatialApiBase {
 		EditableLayer layer = getEditableLayerOrThrow(tx, spatial(), name);
 		WKTReader reader = new WKTReader(layer.getGeometryFactory());
 		Node node = addGeometryWkt(layer, reader, geometryWKT);
-		layer.close(tx);
+		layer.finalizeTransaction(tx);
 		return streamNode(node);
 	}
 
@@ -654,7 +654,7 @@ public class SpatialProcedures extends SpatialApiBase {
 		WKTReader reader = new WKTReader(layer.getGeometryFactory());
 		return geometryWKTs.stream().map(geometryWKT -> addGeometryWkt(layer, reader, geometryWKT))
 				.map(NodeResult::new)
-				.onClose(() -> layer.close(tx));
+				.onClose(() -> layer.finalizeTransaction(tx));
 	}
 
 	private Node addGeometryWkt(EditableLayer layer, WKTReader reader, String geometryWKT) {
@@ -673,7 +673,7 @@ public class SpatialProcedures extends SpatialApiBase {
 			@Name("uri") String uri) throws IOException {
 		EditableLayerImpl layer = getEditableLayerOrThrow(tx, spatial(), name);
 		List<Node> nodes = importShapefileToLayer(uri, layer, 1000);
-		layer.close(tx);
+		layer.finalizeTransaction(tx);
 		return Stream.of(new CountResult(nodes.size()));
 	}
 

--- a/src/main/java/org/neo4j/gis/spatial/rtree/RTreeIndex.java
+++ b/src/main/java/org/neo4j/gis/spatial/rtree/RTreeIndex.java
@@ -1554,4 +1554,9 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 			return Double.compare(o1.envelope.getArea(), o2.envelope.getArea());
 		}
 	}
+
+	@Override
+	public void close(Transaction tx) {
+		saveCount(tx);
+	}
 }

--- a/src/main/java/org/neo4j/gis/spatial/rtree/RTreeIndex.java
+++ b/src/main/java/org/neo4j/gis/spatial/rtree/RTreeIndex.java
@@ -1556,7 +1556,7 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 	}
 
 	@Override
-	public void close(Transaction tx) {
+	public void finalizeTransaction(Transaction tx) {
 		saveCount(tx);
 	}
 }

--- a/src/test/java/org/neo4j/gis/spatial/LayersTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/LayersTest.java
@@ -365,6 +365,7 @@ public class LayersTest {
 				coordinateNodes.add(node);
 			}
 			layer.addAll(tx, coordinateNodes);
+			layer.close(tx);
 			tx.commit();
 		}
 

--- a/src/test/java/org/neo4j/gis/spatial/LayersTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/LayersTest.java
@@ -365,7 +365,7 @@ public class LayersTest {
 				coordinateNodes.add(node);
 			}
 			layer.addAll(tx, coordinateNodes);
-			layer.close(tx);
+			layer.finalizeTransaction(tx);
 			tx.commit();
 		}
 


### PR DESCRIPTION
This PR changes the following procedure to be read-only:

- `spatial.layers`
- `spatial.bbox`
- `spatial.closest`
- `spatial.withinDistance`
- `spatial.intersects`