### PR TITLE
Add Index Configuration Feature to Neo4j Spatial

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,7 +339,6 @@
 			<groupId>org.geotools</groupId>
 			<artifactId>gt-geojson</artifactId>
 			<version>${geotools.version}</version>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.geotools.xsd</groupId>

--- a/src/main/java/org/neo4j/gis/spatial/ShapefileImporter.java
+++ b/src/main/java/org/neo4j/gis/spatial/ShapefileImporter.java
@@ -103,7 +103,7 @@ public class ShapefileImporter implements Constants {
 		EditableLayerImpl layer;
 		try (Transaction tx = database.beginTx()) {
 			layer = (EditableLayerImpl) spatialDatabase.getOrCreateLayer(tx, layerName, WKBGeometryEncoder.class,
-					layerClass);
+					layerClass, null);
 			tx.commit();
 		}
 		return importFile(dataset, layer, charset);

--- a/src/main/java/org/neo4j/gis/spatial/osm/OSMImporter.java
+++ b/src/main/java/org/neo4j/gis/spatial/osm/OSMImporter.java
@@ -250,7 +250,7 @@ public class OSMImporter implements Constants {
 		OSMDataset dataset;
 		try (Transaction tx = beginTx(database)) {
 			layer = (OSMLayer) spatialDatabase.getOrCreateLayer(tx, layerName, OSMGeometryEncoder.class,
-					OSMLayer.class);
+					OSMLayer.class, null);
 			dataset = OSMDataset.withDatasetId(tx, layer, osm_dataset);
 			tx.commit();
 		}

--- a/src/main/java/org/neo4j/gis/spatial/procedures/SpatialProcedures.java
+++ b/src/main/java/org/neo4j/gis/spatial/procedures/SpatialProcedures.java
@@ -211,13 +211,15 @@ public class SpatialProcedures extends SpatialApiBase {
 	public Stream<NodeResult> addSimplePointLayer(
 			@Name("name") String name,
 			@Name(value = "indexType", defaultValue = RTREE_INDEX_NAME) String indexType,
-			@Name(value = "crsName", defaultValue = UNSET_CRS_NAME) String crsName) {
+			@Name(value = "crsName", defaultValue = UNSET_CRS_NAME) String crsName,
+			@Name(value = "indexConfig", defaultValue = UNSET_INDEX_CONFIG) String indexConfig
+	) {
 		SpatialDatabaseService sdb = spatial();
 		Layer layer = sdb.getLayer(tx, name);
 		if (layer == null) {
 			return streamNode(sdb.createLayer(tx, name, SimplePointEncoder.class, SimplePointLayer.class,
-					SpatialDatabaseService.resolveIndexClass(indexType), null,
-					selectCRS(crsName)).getLayerNode(tx));
+							SpatialDatabaseService.resolveIndexClass(indexType), null, indexConfig, selectCRS(crsName))
+					.getLayerNode(tx));
 		}
 		throw new IllegalArgumentException("Cannot create existing layer: " + name);
 	}
@@ -226,37 +228,44 @@ public class SpatialProcedures extends SpatialApiBase {
 	@Description("Adds a new simple point layer with geohash based index, returns the layer root node")
 	public Stream<NodeResult> addSimplePointLayerGeohash(
 			@Name("name") String name,
-			@Name(value = "crsName", defaultValue = WGS84_CRS_NAME) String crsName) {
+			@Name(value = "crsName", defaultValue = WGS84_CRS_NAME) String crsName,
+			@Name(value = "indexConfig", defaultValue = UNSET_INDEX_CONFIG) String indexConfig) {
 		SpatialDatabaseService sdb = spatial();
 		Layer layer = sdb.getLayer(tx, name);
 		if (layer == null) {
 			return streamNode(sdb.createLayer(tx, name, SimplePointEncoder.class, SimplePointLayer.class,
-					LayerGeohashPointIndex.class, null,
-					selectCRS(crsName)).getLayerNode(tx));
+							LayerGeohashPointIndex.class, null, indexConfig, selectCRS(crsName))
+					.getLayerNode(tx));
 		}
 		throw new IllegalArgumentException("Cannot create existing layer: " + name);
 	}
 
 	@Procedure(value = "spatial.addPointLayerZOrder", mode = WRITE)
 	@Description("Adds a new simple point layer with z-order curve based index, returns the layer root node")
-	public Stream<NodeResult> addSimplePointLayerZOrder(@Name("name") String name) {
+	public Stream<NodeResult> addSimplePointLayerZOrder(@Name("name") String name,
+			@Name(value = "indexConfig", defaultValue = UNSET_INDEX_CONFIG) String indexConfig) {
 		SpatialDatabaseService sdb = spatial();
 		Layer layer = sdb.getLayer(tx, name);
 		if (layer == null) {
 			return streamNode(sdb.createLayer(tx, name, SimplePointEncoder.class, SimplePointLayer.class,
-					LayerZOrderPointIndex.class, null, DefaultGeographicCRS.WGS84).getLayerNode(tx));
+							LayerZOrderPointIndex.class, null, indexConfig, DefaultGeographicCRS.WGS84)
+					.getLayerNode(tx));
 		}
 		throw new IllegalArgumentException("Cannot create existing layer: " + name);
 	}
 
 	@Procedure(value = "spatial.addPointLayerHilbert", mode = WRITE)
 	@Description("Adds a new simple point layer with hilbert curve based index, returns the layer root node")
-	public Stream<NodeResult> addSimplePointLayerHilbert(@Name("name") String name) {
+	public Stream<NodeResult> addSimplePointLayerHilbert(
+			@Name("name") String name,
+			@Name(value = "indexConfig", defaultValue = UNSET_INDEX_CONFIG) String indexConfig
+	) {
 		SpatialDatabaseService sdb = spatial();
 		Layer layer = sdb.getLayer(tx, name);
 		if (layer == null) {
 			return streamNode(sdb.createLayer(tx, name, SimplePointEncoder.class, SimplePointLayer.class,
-					LayerHilbertPointIndex.class, null, DefaultGeographicCRS.WGS84).getLayerNode(tx));
+							LayerHilbertPointIndex.class, null, indexConfig, DefaultGeographicCRS.WGS84)
+					.getLayerNode(tx));
 		}
 		throw new IllegalArgumentException("Cannot create existing layer: " + name);
 	}
@@ -268,15 +277,17 @@ public class SpatialProcedures extends SpatialApiBase {
 			@Name("xProperty") String xProperty,
 			@Name("yProperty") String yProperty,
 			@Name(value = "indexType", defaultValue = RTREE_INDEX_NAME) String indexType,
-			@Name(value = "crsName", defaultValue = UNSET_CRS_NAME) String crsName) {
+			@Name(value = "crsName", defaultValue = UNSET_CRS_NAME) String crsName,
+			@Name(value = "indexConfig", defaultValue = UNSET_INDEX_CONFIG) String indexConfig) {
 		SpatialDatabaseService sdb = spatial();
 		Layer layer = sdb.getLayer(tx, name);
 		if (layer == null) {
 			if (xProperty != null && yProperty != null) {
 				return streamNode(sdb.createLayer(tx, name, SimplePointEncoder.class, SimplePointLayer.class,
-						SpatialDatabaseService.resolveIndexClass(indexType),
-						SpatialDatabaseService.makeEncoderConfig(xProperty, yProperty),
-						selectCRS(hintCRSName(crsName, yProperty))).getLayerNode(tx));
+								SpatialDatabaseService.resolveIndexClass(indexType),
+								SpatialDatabaseService.makeEncoderConfig(xProperty, yProperty), indexConfig,
+								selectCRS(hintCRSName(crsName, yProperty)))
+						.getLayerNode(tx));
 			}
 			throw new IllegalArgumentException(
 					"Cannot create layer '" + name + "': Missing encoder config values: xProperty[" + xProperty
@@ -291,14 +302,16 @@ public class SpatialProcedures extends SpatialApiBase {
 			@Name("name") String name,
 			@Name("encoderConfig") String encoderConfig,
 			@Name(value = "indexType", defaultValue = RTREE_INDEX_NAME) String indexType,
-			@Name(value = "crsName", defaultValue = UNSET_CRS_NAME) String crsName) {
+			@Name(value = "crsName", defaultValue = UNSET_CRS_NAME) String crsName,
+			@Name(value = "indexConfig", defaultValue = UNSET_INDEX_CONFIG) String indexConfig) {
 		SpatialDatabaseService sdb = spatial();
 		Layer layer = sdb.getLayer(tx, name);
 		if (layer == null) {
 			if (encoderConfig.indexOf(':') > 0) {
 				return streamNode(sdb.createLayer(tx, name, SimplePointEncoder.class, SimplePointLayer.class,
-						SpatialDatabaseService.resolveIndexClass(indexType), encoderConfig,
-						selectCRS(hintCRSName(crsName, encoderConfig))).getLayerNode(tx));
+								SpatialDatabaseService.resolveIndexClass(indexType), encoderConfig, indexConfig,
+								selectCRS(hintCRSName(crsName, encoderConfig)))
+						.getLayerNode(tx));
 			}
 			throw new IllegalArgumentException(
 					"Cannot create layer '" + name + "': invalid encoder config '" + encoderConfig + "'");
@@ -311,12 +324,14 @@ public class SpatialProcedures extends SpatialApiBase {
 	public Stream<NodeResult> addNativePointLayer(
 			@Name("name") String name,
 			@Name(value = "indexType", defaultValue = RTREE_INDEX_NAME) String indexType,
-			@Name(value = "crsName", defaultValue = UNSET_CRS_NAME) String crsName) {
+			@Name(value = "crsName", defaultValue = UNSET_CRS_NAME) String crsName,
+			@Name(value = "indexConfig", defaultValue = UNSET_INDEX_CONFIG) String indexConfig) {
 		SpatialDatabaseService sdb = spatial();
 		Layer layer = sdb.getLayer(tx, name);
 		if (layer == null) {
 			return streamNode(sdb.createLayer(tx, name, NativePointEncoder.class, SimplePointLayer.class,
-					SpatialDatabaseService.resolveIndexClass(indexType), null, selectCRS(crsName)).getLayerNode(tx));
+							SpatialDatabaseService.resolveIndexClass(indexType), null, indexConfig, selectCRS(crsName))
+					.getLayerNode(tx));
 		}
 		throw new IllegalArgumentException("Cannot create existing layer: " + name);
 	}
@@ -325,36 +340,43 @@ public class SpatialProcedures extends SpatialApiBase {
 	@Description("Adds a new native point layer with geohash based index, returns the layer root node")
 	public Stream<NodeResult> addNativePointLayerGeohash(
 			@Name("name") String name,
-			@Name(value = "crsName", defaultValue = WGS84_CRS_NAME) String crsName) {
+			@Name(value = "crsName", defaultValue = WGS84_CRS_NAME) String crsName,
+			@Name(value = "indexConfig", defaultValue = UNSET_INDEX_CONFIG) String indexConfig) {
 		SpatialDatabaseService sdb = spatial();
 		Layer layer = sdb.getLayer(tx, name);
 		if (layer == null) {
 			return streamNode(sdb.createLayer(tx, name, NativePointEncoder.class, SimplePointLayer.class,
-					LayerGeohashPointIndex.class, null, selectCRS(crsName)).getLayerNode(tx));
+							LayerGeohashPointIndex.class, null, indexConfig, selectCRS(crsName))
+					.getLayerNode(tx));
 		}
 		throw new IllegalArgumentException("Cannot create existing layer: " + name);
 	}
 
 	@Procedure(value = "spatial.addNativePointLayerZOrder", mode = WRITE)
 	@Description("Adds a new native point layer with z-order curve based index, returns the layer root node")
-	public Stream<NodeResult> addNativePointLayerZOrder(@Name("name") String name) {
+	public Stream<NodeResult> addNativePointLayerZOrder(@Name("name") String name,
+			@Name(value = "indexConfig", defaultValue = UNSET_INDEX_CONFIG) String indexConfig) {
 		SpatialDatabaseService sdb = spatial();
 		Layer layer = sdb.getLayer(tx, name);
 		if (layer == null) {
 			return streamNode(sdb.createLayer(tx, name, NativePointEncoder.class, SimplePointLayer.class,
-					LayerZOrderPointIndex.class, null, DefaultGeographicCRS.WGS84).getLayerNode(tx));
+							LayerZOrderPointIndex.class, null, indexConfig, DefaultGeographicCRS.WGS84)
+					.getLayerNode(tx));
 		}
 		throw new IllegalArgumentException("Cannot create existing layer: " + name);
 	}
 
 	@Procedure(value = "spatial.addNativePointLayerHilbert", mode = WRITE)
 	@Description("Adds a new native point layer with hilbert curve based index, returns the layer root node")
-	public Stream<NodeResult> addNativePointLayerHilbert(@Name("name") String name) {
+	public Stream<NodeResult> addNativePointLayerHilbert(@Name("name") String name,
+			@Name(value = "indexConfig", defaultValue = UNSET_INDEX_CONFIG) String indexConfig
+	) {
 		SpatialDatabaseService sdb = spatial();
 		Layer layer = sdb.getLayer(tx, name);
 		if (layer == null) {
 			return streamNode(sdb.createLayer(tx, name, NativePointEncoder.class, SimplePointLayer.class,
-					LayerHilbertPointIndex.class, null, DefaultGeographicCRS.WGS84).getLayerNode(tx));
+							LayerHilbertPointIndex.class, null, indexConfig, DefaultGeographicCRS.WGS84)
+					.getLayerNode(tx));
 		}
 		throw new IllegalArgumentException("Cannot create existing layer: " + name);
 	}
@@ -366,15 +388,17 @@ public class SpatialProcedures extends SpatialApiBase {
 			@Name("xProperty") String xProperty,
 			@Name("yProperty") String yProperty,
 			@Name(value = "indexType", defaultValue = RTREE_INDEX_NAME) String indexType,
-			@Name(value = "crsName", defaultValue = UNSET_CRS_NAME) String crsName) {
+			@Name(value = "crsName", defaultValue = UNSET_CRS_NAME) String crsName,
+			@Name(value = "indexConfig", defaultValue = UNSET_INDEX_CONFIG) String indexConfig) {
 		SpatialDatabaseService sdb = spatial();
 		Layer layer = sdb.getLayer(tx, name);
 		if (layer == null) {
 			if (xProperty != null && yProperty != null) {
 				return streamNode(sdb.createLayer(tx, name, NativePointEncoder.class, SimplePointLayer.class,
-						SpatialDatabaseService.resolveIndexClass(indexType),
-						SpatialDatabaseService.makeEncoderConfig(xProperty, yProperty),
-						selectCRS(hintCRSName(crsName, yProperty))).getLayerNode(tx));
+								SpatialDatabaseService.resolveIndexClass(indexType),
+								SpatialDatabaseService.makeEncoderConfig(xProperty, yProperty), indexConfig,
+								selectCRS(hintCRSName(crsName, yProperty)))
+						.getLayerNode(tx));
 			}
 			throw new IllegalArgumentException(
 					"Cannot create layer '" + name + "': Missing encoder config values: xProperty[" + xProperty
@@ -389,14 +413,16 @@ public class SpatialProcedures extends SpatialApiBase {
 			@Name("name") String name,
 			@Name("encoderConfig") String encoderConfig,
 			@Name(value = "indexType", defaultValue = RTREE_INDEX_NAME) String indexType,
-			@Name(value = "crsName", defaultValue = UNSET_CRS_NAME) String crsName) {
+			@Name(value = "crsName", defaultValue = UNSET_CRS_NAME) String crsName,
+			@Name(value = "indexConfig", defaultValue = UNSET_INDEX_CONFIG) String indexConfig) {
 		SpatialDatabaseService sdb = spatial();
 		Layer layer = sdb.getLayer(tx, name);
 		if (layer == null) {
 			if (encoderConfig.indexOf(':') > 0) {
 				return streamNode(sdb.createLayer(tx, name, NativePointEncoder.class, SimplePointLayer.class,
-						SpatialDatabaseService.resolveIndexClass(indexType), encoderConfig,
-						selectCRS(hintCRSName(crsName, encoderConfig))).getLayerNode(tx));
+								SpatialDatabaseService.resolveIndexClass(indexType), encoderConfig, indexConfig,
+								selectCRS(hintCRSName(crsName, encoderConfig)))
+						.getLayerNode(tx));
 			}
 			throw new IllegalArgumentException(
 					"Cannot create layer '" + name + "': invalid encoder config '" + encoderConfig + "'");
@@ -405,6 +431,7 @@ public class SpatialProcedures extends SpatialApiBase {
 	}
 
 	public static final String UNSET_CRS_NAME = "";
+	public static final String UNSET_INDEX_CONFIG = "";
 	public static final String WGS84_CRS_NAME = "wgs84";
 
 	/**
@@ -437,15 +464,17 @@ public class SpatialProcedures extends SpatialApiBase {
 	public Stream<NodeResult> addLayerWithEncoder(
 			@Name("name") String name,
 			@Name("encoder") String encoderClassName,
-			@Name("encoderConfig") String encoderConfig) {
+			@Name("encoderConfig") String encoderConfig,
+			@Name(value = "indexConfig", defaultValue = UNSET_INDEX_CONFIG) String indexConfig) {
 		SpatialDatabaseService sdb = spatial();
 		Layer layer = sdb.getLayer(tx, name);
 		if (layer == null) {
 			Class<? extends GeometryEncoder> encoderClass = encoderClasses.get(encoderClassName);
 			Class<? extends Layer> layerClass = SpatialDatabaseService.suggestLayerClassForEncoder(encoderClass);
 			if (encoderClass != null) {
-				return streamNode(
-						sdb.createLayer(tx, name, encoderClass, layerClass, null, encoderConfig).getLayerNode(tx));
+				return streamNode(sdb
+						.createLayer(tx, name, encoderClass, layerClass, null, encoderConfig, indexConfig)
+						.getLayerNode(tx));
 			}
 			throw new IllegalArgumentException(
 					"Cannot create layer '" + name + "': invalid encoder class '" + encoderClassName + "'");
@@ -458,13 +487,15 @@ public class SpatialProcedures extends SpatialApiBase {
 	public Stream<NodeResult> addLayerOfType(
 			@Name("name") String name,
 			@Name("type") String type,
-			@Name("encoderConfig") String encoderConfig) {
+			@Name("encoderConfig") String encoderConfig,
+			@Name(value = "indexConfig", defaultValue = UNSET_INDEX_CONFIG) String indexConfig) {
 		SpatialDatabaseService sdb = spatial();
 		Layer layer = sdb.getLayer(tx, name);
 		if (layer == null) {
 			Map<String, String> knownTypes = SpatialDatabaseService.getRegisteredLayerTypes();
 			if (knownTypes.containsKey(type.toLowerCase())) {
-				return streamNode(sdb.getOrCreateRegisteredTypeLayer(tx, name, type, encoderConfig).getLayerNode(tx));
+				return streamNode(sdb.getOrCreateRegisteredTypeLayer(tx, name, type, encoderConfig, indexConfig)
+						.getLayerNode(tx));
 			}
 			throw new IllegalArgumentException(
 					"Cannot create layer '" + name + "': unknown type '" + type + "' - supported types are "
@@ -484,8 +515,9 @@ public class SpatialProcedures extends SpatialApiBase {
 	@Procedure(value = "spatial.addWKTLayer", mode = WRITE)
 	@Description("Adds a new WKT layer with the given node property to hold the WKT string, returns the layer root node")
 	public Stream<NodeResult> addWKTLayer(@Name("name") String name,
-			@Name("nodePropertyName") String nodePropertyName) {
-		return addLayerOfType(name, "WKT", nodePropertyName);
+			@Name("nodePropertyName") String nodePropertyName,
+			@Name(value = "indexConfig", defaultValue = UNSET_INDEX_CONFIG) String indexConfig) {
+		return addLayerOfType(name, "WKT", nodePropertyName, indexConfig);
 	}
 
 	@Procedure(value = "spatial.layer", mode = WRITE)
@@ -671,7 +703,7 @@ public class SpatialProcedures extends SpatialApiBase {
 		// Delegate creating the layer to the inner thread, so we do not pollute the procedure transaction with anything that might conflict.
 		// Since the procedure transaction starts before, and ends after, all inner transactions.
 		BiFunction<Transaction, String, OSMLayer> layerMaker = (tx, name) -> (OSMLayer) spatial().getOrCreateLayer(tx,
-				name, OSMGeometryEncoder.class, OSMLayer.class);
+				name, OSMGeometryEncoder.class, OSMLayer.class, "");
 		return Stream.of(new CountResult(importOSMToLayer(uri, layerName, layerMaker)));
 	}
 

--- a/src/main/java/org/neo4j/gis/spatial/rtree/RTreeIndex.java
+++ b/src/main/java/org/neo4j/gis/spatial/rtree/RTreeIndex.java
@@ -67,6 +67,7 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 
 	public static final String KEY_MAX_NODE_REFERENCES = "maxNodeReferences";
 	public static final String KEY_SHOULD_MERGE_TREES = "shouldMergeTrees";
+	public static final String REFERENCE_RELATIONSHIP_TYPE = "referenceRelationshipType";
 	public static final int MIN_MAX_NODE_REFERENCES = 10;
 	public static final int MAX_MAX_NODE_REFERENCES = 1000000;
 	public static final int DEFAULT_MAX_NODE_REFERENCES = 100;
@@ -77,6 +78,7 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 	private int maxNodeReferences;
 	private String splitMode = GREENES_SPLIT;
 	private boolean shouldMergeTrees = false;
+	private RelationshipType referenceRelationshipType = RTreeRelationshipTypes.RTREE_REFERENCE;
 
 	private int totalGeometryCount = 0;
 	private boolean countSaved = false;
@@ -106,6 +108,9 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 
 	@Override
 	public void setConfiguration(String jsonConfig) {
+		if (jsonConfig == null || jsonConfig.isBlank()) {
+			return;
+		}
 		JSONObject jsonObject = (JSONObject) JSONValue.parse(jsonConfig);
 		HashMap<String, Object> config = new HashMap<>();
 		for (Object key : jsonObject.keySet()) {
@@ -120,26 +125,28 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 		config.put(KEY_SPLIT, this.splitMode);
 		config.put(KEY_MAX_NODE_REFERENCES, this.maxNodeReferences);
 		config.put(KEY_SHOULD_MERGE_TREES, this.shouldMergeTrees);
+		config.put(REFERENCE_RELATIONSHIP_TYPE, this.referenceRelationshipType.name());
 		return JSONObject.toJSONString(config);
 	}
 
 	@Override
 	public void configure(Map<String, Object> config) {
-		for (String key : config.keySet()) {
+		config.forEach((key, rawValue) -> {
 			switch (key) {
 				case KEY_SPLIT:
-					String value = config.get(key).toString();
+					String value = rawValue.toString();
 					switch (value) {
 						case QUADRATIC_SPLIT:
 						case GREENES_SPLIT:
 							splitMode = value;
 							break;
 						default:
-							throw new IllegalArgumentException("No such RTreeIndex value for '" + key + "': " + value);
+							throw new IllegalArgumentException(
+									"No such RTreeIndex value for '" + key + "': " + rawValue);
 					}
 					break;
 				case KEY_MAX_NODE_REFERENCES:
-					int intValue = Integer.parseInt(config.get(key).toString());
+					int intValue = Integer.parseInt(rawValue.toString());
 					if (intValue < MIN_MAX_NODE_REFERENCES) {
 						throw new IllegalArgumentException(
 								"RTreeIndex does not allow " + key + " less than " + MIN_MAX_NODE_REFERENCES);
@@ -151,12 +158,15 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 					this.maxNodeReferences = intValue;
 					break;
 				case KEY_SHOULD_MERGE_TREES:
-					this.shouldMergeTrees = Boolean.parseBoolean(config.get(key).toString());
+					this.shouldMergeTrees = Boolean.parseBoolean(rawValue.toString());
+					break;
+				case REFERENCE_RELATIONSHIP_TYPE:
+					this.referenceRelationshipType = RelationshipType.withName(rawValue.toString());
 					break;
 				default:
 					throw new IllegalArgumentException("No such RTreeIndex configuration key: " + key);
 			}
-		}
+		});
 	}
 
 	@Override
@@ -177,7 +187,7 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 			parent = chooseSubTree(parent, geomNode);
 		}
 		// bbox enlargement needed
-		if (countChildren(parent, RTreeRelationshipTypes.RTREE_REFERENCE) >= maxNodeReferences) {
+		if (countChildren(parent, referenceRelationshipType) >= maxNodeReferences) {
 			insertInLeaf(parent, geomNode);
 			splitAndAdjustPathBoundingBox(tx, parent);
 		} else if (insertInLeaf(parent, geomNode)) {
@@ -404,7 +414,7 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 					int newHeight = getHeight(newRootNode, 0);
 					if (newHeight == 1) {
 						monitor.addCase("h_i > l_t (d==1)");
-						try (var relationships = newRootNode.getRelationships(RTreeRelationshipTypes.RTREE_REFERENCE)) {
+						try (var relationships = newRootNode.getRelationships(referenceRelationshipType)) {
 							for (Relationship geom : relationships) {
 								addBelow(tx, child.node, geom.getEndNode());
 								geom.delete();
@@ -615,7 +625,7 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 
 				// remove the entry
 				final Relationship geometryRtreeReference = geomNode.getSingleRelationship(
-						RTreeRelationshipTypes.RTREE_REFERENCE, Direction.INCOMING);
+						referenceRelationshipType, Direction.INCOMING);
 				if (geometryRtreeReference != null) {
 					geometryRtreeReference.delete();
 				}
@@ -624,11 +634,11 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 				}
 
 				// reorganize the tree if needed
-				if (countChildren(indexNode, RTreeRelationshipTypes.RTREE_REFERENCE) == 0) {
-					indexNode = deleteEmptyTreeNodes(indexNode, RTreeRelationshipTypes.RTREE_REFERENCE);
+				if (countChildren(indexNode, referenceRelationshipType) == 0) {
+					indexNode = deleteEmptyTreeNodes(indexNode, referenceRelationshipType);
 					adjustParentBoundingBox(indexNode, RTreeRelationshipTypes.RTREE_CHILD);
 				} else {
-					adjustParentBoundingBox(indexNode, RTreeRelationshipTypes.RTREE_REFERENCE);
+					adjustParentBoundingBox(indexNode, referenceRelationshipType);
 				}
 
 				adjustPathBoundingBox(indexNode);
@@ -670,7 +680,7 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 
 				@Override
 				public void onIndexReference(Node geomNode) {
-					geomNode.getSingleRelationship(RTreeRelationshipTypes.RTREE_REFERENCE, Direction.INCOMING).delete();
+					geomNode.getSingleRelationship(referenceRelationshipType, Direction.INCOMING).delete();
 					if (deleteGeomNodes) {
 						deleteNode(geomNode);
 					}
@@ -791,7 +801,7 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 						Evaluation.EXCLUDE_AND_CONTINUE :
 						Evaluation.EXCLUDE_AND_PRUNE;
 			}
-			if (rel.isType(RTreeRelationshipTypes.RTREE_REFERENCE)) {
+			if (rel.isType(referenceRelationshipType)) {
 				boolean found;
 				if (state.getState() == SearchFilter.EnvelopFilterResult.INCLUDE_ALL) {
 					found = true;
@@ -818,7 +828,7 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 				.depthFirst()
 				.expand(StandardExpander.DEFAULT, path -> SearchFilter.EnvelopFilterResult.FILTER)
 				.relationships(RTreeRelationshipTypes.RTREE_CHILD, Direction.OUTGOING)
-				.relationships(RTreeRelationshipTypes.RTREE_REFERENCE, Direction.OUTGOING)
+				.relationships(referenceRelationshipType, Direction.OUTGOING)
 				.evaluator(searchEvaluator);
 		Traverser traverser = td.traverse(getIndexRoot(tx));
 		return new SearchResults(traverser.nodes());
@@ -840,9 +850,9 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 				}
 			}
 		} else // Node is a leaf
-			if (indexNode.hasRelationship(Direction.OUTGOING, RTreeRelationshipTypes.RTREE_REFERENCE)) {
+			if (indexNode.hasRelationship(Direction.OUTGOING, referenceRelationshipType)) {
 				try (var relationships = indexNode.getRelationships(Direction.OUTGOING,
-						RTreeRelationshipTypes.RTREE_REFERENCE)) {
+						referenceRelationshipType)) {
 					for (Relationship rel : relationships) {
 						visitor.onIndexReference(rel.getEndNode());
 					}
@@ -862,7 +872,7 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 	 * know whether the child is a leaf or an index node.
 	 */
 	private Envelope getChildNodeEnvelope(Node child, RelationshipType relType) {
-		if (relType.name().equals(RTreeRelationshipTypes.RTREE_REFERENCE.name())) {
+		if (relType.name().equals(referenceRelationshipType.name())) {
 			return getLeafNodeEnvelope(child);
 		}
 		return getIndexNodeEnvelope(child);
@@ -892,7 +902,7 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 		return new Envelope(bbox[0], bbox[2], bbox[1], bbox[3]);
 	}
 
-	private static void visitInTx(Transaction tx, SpatialIndexVisitor visitor, String indexNodeId) {
+	private void visitInTx(Transaction tx, SpatialIndexVisitor visitor, String indexNodeId) {
 		Node indexNode = tx.getNodeByElementId(indexNodeId);
 		if (!visitor.needsToVisit(getIndexNodeEnvelope(indexNode))) {
 			return;
@@ -915,9 +925,9 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 				visitInTx(tx, visitor, child);
 			}
 		} else // Node is a leaf
-			if (indexNode.hasRelationship(Direction.OUTGOING, RTreeRelationshipTypes.RTREE_REFERENCE)) {
+			if (indexNode.hasRelationship(Direction.OUTGOING, referenceRelationshipType)) {
 				try (var relationships = indexNode.getRelationships(Direction.OUTGOING,
-						RTreeRelationshipTypes.RTREE_REFERENCE)) {
+						referenceRelationshipType)) {
 					for (Relationship rel : relationships) {
 						visitor.onIndexReference(rel.getEndNode());
 					}
@@ -1071,7 +1081,7 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 	 * @return is enlargement needed?
 	 */
 	private boolean insertInLeaf(Node indexNode, Node geomRootNode) {
-		return addChild(indexNode, RTreeRelationshipTypes.RTREE_REFERENCE, geomRootNode);
+		return addChild(indexNode, referenceRelationshipType, geomRootNode);
 	}
 
 	private void splitAndAdjustPathBoundingBox(Transaction tx, Node indexNode) {
@@ -1098,14 +1108,14 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 
 	private Node quadraticSplit(Transaction tx, Node indexNode) {
 		if (nodeIsLeaf(indexNode)) {
-			return quadraticSplit(tx, indexNode, RTreeRelationshipTypes.RTREE_REFERENCE);
+			return quadraticSplit(tx, indexNode, referenceRelationshipType);
 		}
 		return quadraticSplit(tx, indexNode, RTreeRelationshipTypes.RTREE_CHILD);
 	}
 
 	private Node greenesSplit(Transaction tx, Node indexNode) {
 		if (nodeIsLeaf(indexNode)) {
-			return greenesSplit(tx, indexNode, RTreeRelationshipTypes.RTREE_REFERENCE);
+			return greenesSplit(tx, indexNode, referenceRelationshipType);
 		}
 		return greenesSplit(tx, indexNode, RTreeRelationshipTypes.RTREE_CHILD);
 	}
@@ -1425,12 +1435,12 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 		node.delete();
 	}
 
-	protected static boolean isGeometryNodeIndexed(Node geomNode) {
-		return geomNode.hasRelationship(Direction.INCOMING, RTreeRelationshipTypes.RTREE_REFERENCE);
+	protected boolean isGeometryNodeIndexed(Node geomNode) {
+		return geomNode.hasRelationship(Direction.INCOMING, referenceRelationshipType);
 	}
 
-	protected static Node findLeafContainingGeometryNode(Node geomNode) {
-		return geomNode.getSingleRelationship(RTreeRelationshipTypes.RTREE_REFERENCE, Direction.INCOMING)
+	protected Node findLeafContainingGeometryNode(Node geomNode) {
+		return geomNode.getSingleRelationship(referenceRelationshipType, Direction.INCOMING)
 				.getStartNode();
 	}
 
@@ -1488,7 +1498,7 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 	 * the objects from one type to another without loading all into memory,
 	 * we need to use this ugly java-magic. Man, I miss Ruby right now!
 	 */
-	private static class IndexNodeToGeometryNodeIterable implements Iterable<Node> {
+	private class IndexNodeToGeometryNodeIterable implements Iterable<Node> {
 
 		private final Iterator<Node> allIndexNodeIterator;
 
@@ -1512,7 +1522,7 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 				MonoDirectionalTraversalDescription traversal = new MonoDirectionalTraversalDescription();
 				TraversalDescription td = traversal
 						.depthFirst()
-						.relationships(RTreeRelationshipTypes.RTREE_REFERENCE, Direction.OUTGOING)
+						.relationships(referenceRelationshipType, Direction.OUTGOING)
 						.evaluator(Evaluators.excludeStartPosition())
 						.evaluator(Evaluators.toDepth(1));
 				while ((geometryNodeIterator == null || !geometryNodeIterator.hasNext()) &&

--- a/src/test/java/org/neo4j/gis/spatial/LayerSignatureTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/LayerSignatureTest.java
@@ -64,19 +64,19 @@ public class LayerSignatureTest extends Neo4jTestCase implements Constants {
 	@Test
 	public void testSimpleWKBLayer() {
 		testLayerSignature("EditableLayer(name='test', encoder=WKBGeometryEncoder(geom='geometry', bbox='bbox'))",
-				tx -> spatial.createWKBLayer(tx, "test"));
+				tx -> spatial.createWKBLayer(tx, "test", null));
 	}
 
 	@Test
 	public void testWKBLayer() {
 		testLayerSignature("EditableLayer(name='test', encoder=WKBGeometryEncoder(geom='wkb', bbox='bbox'))",
-				tx -> spatial.getOrCreateEditableLayer(tx, "test", "wkb", "wkb"));
+				tx -> spatial.getOrCreateEditableLayer(tx, "test", "wkb", "wkb", null));
 	}
 
 	@Test
 	public void testWKTLayer() {
 		testLayerSignature("EditableLayer(name='test', encoder=WKTGeometryEncoder(geom='wkt', bbox='bbox'))",
-				tx -> spatial.getOrCreateEditableLayer(tx, "test", "wkt", "wkt"));
+				tx -> spatial.getOrCreateEditableLayer(tx, "test", "wkt", "wkt", null));
 	}
 
 	private Layer testLayerSignature(String signature, Function<Transaction, Layer> layerMaker) {
@@ -100,7 +100,7 @@ public class LayerSignatureTest extends Neo4jTestCase implements Constants {
 	public void testDynamicLayer() {
 		Layer layer = testLayerSignature(
 				"EditableLayer(name='test', encoder=WKTGeometryEncoder(geom='wkt', bbox='bbox'))",
-				tx -> spatial.getOrCreateEditableLayer(tx, "test", "wkt", "wkt"));
+				tx -> spatial.getOrCreateEditableLayer(tx, "test", "wkt", "wkt", null));
 		inTx(tx -> {
 			DynamicLayer dynamic = spatial.asDynamicLayer(tx, layer);
 			assertEquals("EditableLayer(name='test', encoder=WKTGeometryEncoder(geom='wkt', bbox='bbox'))",

--- a/src/test/java/org/neo4j/gis/spatial/LayersTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/LayersTest.java
@@ -92,7 +92,7 @@ public class LayersTest {
 			assertNull(layer);
 		});
 		inTx(tx -> {
-			Layer layer = spatial.createWKBLayer(tx, layerName);
+			Layer layer = spatial.createWKBLayer(tx, layerName, null);
 			assertNotNull(layer);
 			assertThat("Should be a default layer", layer instanceof DefaultLayer);
 		});
@@ -128,7 +128,7 @@ public class LayersTest {
 				new IndexManager((GraphDatabaseAPI) graphDb, SecurityContext.AUTH_DISABLED));
 		inTx(tx -> {
 			EditableLayer layer = (EditableLayer) spatial.createLayer(tx, layerName, encoderClass,
-					EditableLayerImpl.class, indexClass, null);
+					EditableLayerImpl.class, indexClass, null, null);
 			assertNotNull(layer);
 		});
 		inTx(tx -> {
@@ -178,7 +178,7 @@ public class LayersTest {
 				new IndexManager((GraphDatabaseAPI) graphDb, SecurityContext.AUTH_DISABLED));
 		inTx(tx -> {
 			EditableLayer layer = (EditableLayer) spatial.createLayer(tx, layerName, encoderClass,
-					EditableLayerImpl.class, null, null);
+					EditableLayerImpl.class, null, null, null);
 			assertNotNull(layer);
 		});
 		inTx(tx -> {
@@ -197,7 +197,7 @@ public class LayersTest {
 		SpatialDatabaseService spatial = new SpatialDatabaseService(
 				new IndexManager((GraphDatabaseAPI) graphDb, SecurityContext.AUTH_DISABLED));
 		inTx(tx -> {
-			EditableLayer layer = spatial.getOrCreateEditableLayer(tx, layerName);
+			EditableLayer layer = spatial.getOrCreateEditableLayer(tx, layerName, null, null);
 			assertNotNull(layer);
 		});
 		inTx(tx -> {
@@ -234,7 +234,7 @@ public class LayersTest {
 		SpatialDatabaseService spatial = new SpatialDatabaseService(
 				new IndexManager((GraphDatabaseAPI) graphDb, SecurityContext.AUTH_DISABLED));
 		inTx(tx -> {
-			EditableLayer layer = spatial.getOrCreateEditableLayer(tx, "roads");
+			EditableLayer layer = spatial.getOrCreateEditableLayer(tx, "roads", null, null);
 			Coordinate crossing_bygg_forstadsgatan = new Coordinate(13.0171471, 55.6074148);
 			Coordinate[] waypoints_forstadsgatan = {new Coordinate(13.0201511, 55.6066846),
 					crossing_bygg_forstadsgatan};
@@ -272,7 +272,7 @@ public class LayersTest {
 		SpatialDatabaseService spatial = new SpatialDatabaseService(
 				new IndexManager((GraphDatabaseAPI) graphDb, SecurityContext.AUTH_DISABLED));
 		inTx(tx -> {
-			Layer layer = spatial.createLayer(tx, layerName, geometryEncoderClass, layerClass);
+			Layer layer = spatial.createLayer(tx, layerName, geometryEncoderClass, layerClass, null);
 			assertNotNull(layer);
 			assertInstanceOf(EditableLayer.class, layer, "Should be an editable layer");
 		});
@@ -350,7 +350,7 @@ public class LayersTest {
 //        GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase(dbPath.getCanonicalPath());
 		SpatialDatabaseService spatial = new SpatialDatabaseService(
 				new IndexManager((GraphDatabaseAPI) graphDb, SecurityContext.AUTH_DISABLED));
-		inTx(tx -> spatial.getOrCreateSimplePointLayer(tx, "Coordinates", "rtree", "lat", "lon"));
+		inTx(tx -> spatial.getOrCreateSimplePointLayer(tx, "Coordinates", "rtree", "lat", "lon", null));
 
 		Random rand = new Random();
 

--- a/src/test/java/org/neo4j/gis/spatial/OsmAnalysisTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/OsmAnalysisTest.java
@@ -353,7 +353,7 @@ public class OsmAnalysisTest extends TestOSMImportBase {
 				}
 
 				EditableLayerImpl layer = (EditableLayerImpl) spatialService.createLayer(tx, name,
-						WKBGeometryEncoder.class, EditableLayerImpl.class);
+						WKBGeometryEncoder.class, EditableLayerImpl.class, "");
 				layer.setExtraPropertyNames(
 						new String[]{"user_id", "user_name", "year", "month", "dayOfMonth", "weekOfYear"}, tx);
 

--- a/src/test/java/org/neo4j/gis/spatial/RTreeBulkInsertTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/RTreeBulkInsertTest.java
@@ -179,7 +179,7 @@ public class RTreeBulkInsertTest {
 		CoordinateReferenceSystem crs = DefaultEngineeringCRS.GENERIC_2D;
 		try (Transaction tx = db.beginTx()) {
 			SpatialDatabaseService sdbs = spatial();
-			EditableLayer layer = sdbs.getOrCreateSimplePointLayer(tx, name, index, xProperty, yProperty);
+			EditableLayer layer = sdbs.getOrCreateSimplePointLayer(tx, name, index, xProperty, yProperty, null);
 			layer.setCoordinateReferenceSystem(tx, crs);
 			tx.commit();
 			return layer;
@@ -1255,7 +1255,7 @@ public class RTreeBulkInsertTest {
 			System.out.println("BulkLoadingTestRun " + j);
 			try (Transaction tx = db.beginTx()) {
 
-				EditableLayer layer = sdbs.getOrCreateSimplePointLayer(tx, "BulkLoader", "rtree", "lon", "lat");
+				EditableLayer layer = sdbs.getOrCreateSimplePointLayer(tx, "BulkLoader", "rtree", "lon", "lat", null);
 				List<Node> coords = new ArrayList<>(N);
 				for (int i = 0; i < N; i++) {
 					Node n = tx.createNode(Label.label("Coordinate"));

--- a/src/test/java/org/neo4j/gis/spatial/TestOSMImportBase.java
+++ b/src/test/java/org/neo4j/gis/spatial/TestOSMImportBase.java
@@ -66,7 +66,7 @@ public class TestOSMImportBase extends Neo4jTestCase {
 			SpatialDatabaseService spatial = new SpatialDatabaseService(
 					new IndexManager((GraphDatabaseAPI) db, SecurityContext.AUTH_DISABLED));
 			OSMLayer layer = (OSMLayer) spatial.getOrCreateLayer(tx, layerName, OSMGeometryEncoder.class,
-					OSMLayer.class);
+					OSMLayer.class, null);
 			Assertions.assertNotNull(layer.getIndex(), "OSM Layer index should not be null");
 			Assertions.assertNotNull(layer.getIndex().getBoundingBox(tx),
 					"OSM Layer index envelope should not be null");

--- a/src/test/java/org/neo4j/gis/spatial/TestRemove.java
+++ b/src/test/java/org/neo4j/gis/spatial/TestRemove.java
@@ -37,7 +37,7 @@ public class TestRemove extends Neo4jTestCase {
 				new IndexManager((GraphDatabaseAPI) graphDb(), SecurityContext.AUTH_DISABLED));
 
 		try (Transaction tx = graphDb().beginTx()) {
-			spatial.createLayer(tx, layerName, WKTGeometryEncoder.class, EditableLayerImpl.class);
+			spatial.createLayer(tx, layerName, WKTGeometryEncoder.class, EditableLayerImpl.class, "");
 			tx.commit();
 		}
 

--- a/src/test/java/org/neo4j/gis/spatial/TestSpatialQueries.java
+++ b/src/test/java/org/neo4j/gis/spatial/TestSpatialQueries.java
@@ -53,7 +53,7 @@ public class TestSpatialQueries extends Neo4jTestCase {
 		Geometry longLineString;
 		Geometry point;
 		try (Transaction tx = graphDb().beginTx()) {
-			EditableLayer layer = spatial.getOrCreateEditableLayer(tx, layerName, "WKT");
+			EditableLayer layer = spatial.getOrCreateEditableLayer(tx, layerName, "WKT", null);
 			WKTReader wkt = new WKTReader(layer.getGeometryFactory());
 			shortLineString = wkt.read("LINESTRING(16.3493032 48.199882,16.3479487 48.1997337)");
 			longLineString = wkt.read(

--- a/src/test/java/org/neo4j/gis/spatial/TestSpatialUtils.java
+++ b/src/test/java/org/neo4j/gis/spatial/TestSpatialUtils.java
@@ -48,7 +48,7 @@ public class TestSpatialUtils extends Neo4jTestCase {
 				new IndexManager((GraphDatabaseAPI) graphDb(), SecurityContext.AUTH_DISABLED));
 		Geometry geometry;
 		try (Transaction tx = graphDb().beginTx()) {
-			EditableLayer layer = spatial.getOrCreateEditableLayer(tx, "jts");
+			EditableLayer layer = spatial.getOrCreateEditableLayer(tx, "jts", null, null);
 			Coordinate[] coordinates = new Coordinate[]{new Coordinate(0, 0), new Coordinate(0, 1),
 					new Coordinate(1, 1)};
 			geometry = layer.getGeometryFactory().createLineString(coordinates);
@@ -145,7 +145,7 @@ public class TestSpatialUtils extends Neo4jTestCase {
 			OSMDataset.fromLayer(tx, osmLayer); // cache for future usage below
 			GeometryFactory factory = osmLayer.getGeometryFactory();
 			EditableLayerImpl resultsLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx,
-					"testSnapping_results");
+					"testSnapping_results", null, null);
 			String[] fieldsNames = new String[]{"snap-id", "description", "distance"};
 			resultsLayer.setExtraPropertyNames(fieldsNames, tx);
 			Point point = factory.createPoint(new Coordinate(12.9777, 56.0555));

--- a/src/test/java/org/neo4j/gis/spatial/index/LayerIndexTestBase.java
+++ b/src/test/java/org/neo4j/gis/spatial/index/LayerIndexTestBase.java
@@ -170,7 +170,7 @@ public abstract class LayerIndexTestBase {
 
 	private SimplePointLayer makeTestPointLayer() {
 		try (Transaction tx = graph.beginTx()) {
-			SimplePointLayer layer = spatial.createPointLayer(tx, "test", getIndexClass(), getEncoderClass());
+			SimplePointLayer layer = spatial.createPointLayer(tx, "test", getIndexClass(), getEncoderClass(), null);
 			tx.commit();
 			return layer;
 		}

--- a/src/test/java/org/neo4j/gis/spatial/pipes/GeoPipesDocTest.java
+++ b/src/test/java/org/neo4j/gis/spatial/pipes/GeoPipesDocTest.java
@@ -946,7 +946,7 @@ public class GeoPipesDocTest extends AbstractJavaDocTestBase {
 			loadTestOsmData("two-street.osm", 100);
 			osmLayer = spatial.getLayer(tx, "two-street.osm");
 
-			boxesLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "boxes");
+			boxesLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "boxes", null, null);
 			boxesLayer.setExtraPropertyNames(new String[]{"name"}, tx);
 			boxesLayer.setCoordinateReferenceSystem(tx, DefaultEngineeringCRS.GENERIC_2D);
 			WKTReader reader = new WKTReader(boxesLayer.getGeometryFactory());
@@ -957,19 +957,19 @@ public class GeoPipesDocTest extends AbstractJavaDocTestBase {
 					reader.read("POLYGON ((2 3, 2 5, 6 5, 6 3, 2 3))"),
 					new String[]{"name"}, new Object[]{"B"});
 
-			concaveLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "concave");
+			concaveLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "concave", null, null);
 			concaveLayer.setCoordinateReferenceSystem(tx, DefaultEngineeringCRS.GENERIC_2D);
 			reader = new WKTReader(concaveLayer.getGeometryFactory());
 			concaveLayer.add(tx, reader.read("POLYGON ((0 0, 2 5, 0 10, 10 10, 10 0, 0 0))"));
 
-			intersectionLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "intersection");
+			intersectionLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "intersection", null, null);
 			intersectionLayer.setCoordinateReferenceSystem(tx, DefaultEngineeringCRS.GENERIC_2D);
 			reader = new WKTReader(intersectionLayer.getGeometryFactory());
 			intersectionLayer.add(tx, reader.read("POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0))"));
 			intersectionLayer.add(tx, reader.read("POLYGON ((4 4, 4 10, 10 10, 10 4, 4 4))"));
 			intersectionLayer.add(tx, reader.read("POLYGON ((2 2, 2 6, 6 6, 6 2, 2 2))"));
 
-			equalLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "equal");
+			equalLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "equal", null, null);
 			equalLayer.setExtraPropertyNames(new String[]{"id", "name"}, tx);
 			equalLayer.setCoordinateReferenceSystem(tx, DefaultEngineeringCRS.GENERIC_2D);
 			reader = new WKTReader(intersectionLayer.getGeometryFactory());
@@ -984,7 +984,7 @@ public class GeoPipesDocTest extends AbstractJavaDocTestBase {
 					reader.read("POLYGON ((0 0, 0 2, 0 4, 0 5, 5 5, 5 3, 5 2, 5 0, 0 0))"),
 					new String[]{"id", "name"}, new Object[]{4, "topo equal"});
 
-			linesLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "lines");
+			linesLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "lines", null, null);
 			linesLayer.setCoordinateReferenceSystem(tx, DefaultEngineeringCRS.GENERIC_2D);
 			reader = new WKTReader(intersectionLayer.getGeometryFactory());
 			linesLayer.add(tx, reader.read("LINESTRING (12 26, 15 27, 18 32, 20 38, 23 34)"));


### PR DESCRIPTION
# Overview

This PR introduces a new feature allowing users to configure spatial indexes in Neo4j Spatial. Previously, it was not possible to index the same Node with two separate indexes. This update addresses that limitation by introducing customizable index configurations, including a new referenceRelationshipType option.

# Key Changes:

## Index Configuration Options:

* Added support for custom configuration of spatial indexes.
* Users can now specify all the config parameters available for an index
* Add `referenceRelationshipType` as config parameter to the p`RTreeIndex`

## Code Enhancements:

* Modified index creation logic to incorporate configuration options.
* Ensured backward compatibility with default configurations.

## Tests and Validation:

* Added unit tests for the new configuration options.
* Ensured all existing tests pass.

## Usage:

```cypher
// create 1st index
CALL spatial.addLayer('point1','NativePoint','point1:point1BB', '{"referenceRelationshipType": "RTREE_P1_TYPE"}')

// create 2nd index
CALL spatial.addLayer('point2','NativePoint','point2:point2BB', '{"referenceRelationshipType": "RTREE_P2_TYPE"}')
```

Now you can add the same Node to both indexes:

```cypher
UNWIND range(1,$count) as i
CREATE (n:Point {
    id: i,
    point1: point( { latitude: 56.0, longitude: 12.0 } ),
    point2: point( { latitude: 57.0, longitude: 13.0 } )
})

MATCH (p:Point)
WITH (count(p) / 10) AS pages, collect(p) AS nodes
UNWIND range(0, pages) AS i CALL {
    WITH i, nodes
    CALL spatial.addNodes('point1', nodes[(i * 10)..((i + 1) * 10)]) YIELD count
    RETURN count AS count
} IN TRANSACTIONS OF 1 ROWS
RETURN sum(count) AS count

MATCH (p:Point)
WITH (count(p) / 10) AS pages, collect(p) AS nodes
UNWIND range(0, pages) AS i CALL {
    WITH i, nodes
    CALL spatial.addNodes('point2', nodes[(i * 10)..((i + 1) * 10)]) YIELD count
    RETURN count AS count
} IN TRANSACTIONS OF 1 ROWS
RETURN sum(count) AS count

```