### PR TITLE
Add Shortcut for `spatial.intersects` procedure

### DIFF
--- a/src/main/java/org/neo4j/gis/spatial/rtree/RTreeIndex.java
+++ b/src/main/java/org/neo4j/gis/spatial/rtree/RTreeIndex.java
@@ -42,9 +42,11 @@ import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.impl.StandardExpander;
+import org.neo4j.graphdb.traversal.BranchState;
 import org.neo4j.graphdb.traversal.Evaluation;
-import org.neo4j.graphdb.traversal.Evaluator;
 import org.neo4j.graphdb.traversal.Evaluators;
+import org.neo4j.graphdb.traversal.PathEvaluator;
 import org.neo4j.graphdb.traversal.TraversalDescription;
 import org.neo4j.graphdb.traversal.Traverser;
 import org.neo4j.kernel.impl.traversal.MonoDirectionalTraversalDescription;
@@ -754,7 +756,7 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 		return new IndexNodeToGeometryNodeIterable(getAllIndexInternalNodes(tx));
 	}
 
-	private class SearchEvaluator implements Evaluator {
+	private class SearchEvaluator extends PathEvaluator.Adapter<SearchFilter.EnvelopFilterResult> {
 
 		private final SearchFilter filter;
 		private final Transaction tx;
@@ -765,14 +767,22 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 		}
 
 		@Override
-		public Evaluation evaluate(Path path) {
+		public Evaluation evaluate(Path path, BranchState<SearchFilter.EnvelopFilterResult> state) {
 			Relationship rel = path.lastRelationship();
 			Node node = path.endNode();
 			if (rel == null) {
 				return Evaluation.EXCLUDE_AND_CONTINUE;
 			}
 			if (rel.isType(RTreeRelationshipTypes.RTREE_CHILD)) {
-				boolean shouldContinue = filter.needsToVisit(getIndexNodeEnvelope(node));
+				boolean shouldContinue;
+				if (state.getState() == SearchFilter.EnvelopFilterResult.INCLUDE_ALL) {
+					shouldContinue = true;
+				} else {
+					SearchFilter.EnvelopFilterResult envelopFilterResult = filter.needsToVisitExtended(
+							getIndexNodeEnvelope(node));
+					state.setState(envelopFilterResult);
+					shouldContinue = envelopFilterResult != SearchFilter.EnvelopFilterResult.EXCLUDE_ALL;
+				}
 				if (shouldContinue) {
 					monitor.matchedTreeNode(path.length(), node);
 				}
@@ -782,7 +792,12 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 						Evaluation.EXCLUDE_AND_PRUNE;
 			}
 			if (rel.isType(RTreeRelationshipTypes.RTREE_REFERENCE)) {
-				boolean found = filter.geometryMatches(tx, node);
+				boolean found;
+				if (state.getState() == SearchFilter.EnvelopFilterResult.INCLUDE_ALL) {
+					found = true;
+				} else {
+					found = filter.geometryMatches(tx, node);
+				}
 				monitor.addCase(found ? "Geometry Matches" : "Geometry Does NOT Match");
 				if (found) {
 					monitor.setHeight(path.length());
@@ -801,6 +816,7 @@ public class RTreeIndex implements SpatialIndexWriter, Configurable {
 		MonoDirectionalTraversalDescription traversal = new MonoDirectionalTraversalDescription();
 		TraversalDescription td = traversal
 				.depthFirst()
+				.expand(StandardExpander.DEFAULT, path -> SearchFilter.EnvelopFilterResult.FILTER)
 				.relationships(RTreeRelationshipTypes.RTREE_CHILD, Direction.OUTGOING)
 				.relationships(RTreeRelationshipTypes.RTREE_REFERENCE, Direction.OUTGOING)
 				.evaluator(searchEvaluator);

--- a/src/main/java/org/neo4j/gis/spatial/rtree/filter/AbstractSearchEnvelopeIntersection.java
+++ b/src/main/java/org/neo4j/gis/spatial/rtree/filter/AbstractSearchEnvelopeIntersection.java
@@ -44,12 +44,11 @@ public abstract class AbstractSearchEnvelopeIntersection implements SearchFilter
 	}
 
 	@Override
-	public final boolean geometryMatches(Transaction tx, Node geomNode) {
+	public boolean geometryMatches(Transaction tx, Node geomNode) {
 		Envelope geomEnvelope = decoder.decodeEnvelope(geomNode);
 		if (geomEnvelope.intersects(referenceEnvelope)) {
 			return onEnvelopeIntersection(geomNode, geomEnvelope);
 		}
-
 		return false;
 	}
 

--- a/src/main/java/org/neo4j/gis/spatial/rtree/filter/SearchFilter.java
+++ b/src/main/java/org/neo4j/gis/spatial/rtree/filter/SearchFilter.java
@@ -25,8 +25,14 @@ import org.neo4j.graphdb.Transaction;
 
 public interface SearchFilter {
 
+	enum EnvelopFilterResult {
+		INCLUDE_ALL, EXCLUDE_ALL, FILTER
+	}
 	boolean needsToVisit(Envelope envelope);
 
+	default EnvelopFilterResult needsToVisitExtended(Envelope envelope) {
+		return needsToVisit(envelope) ? EnvelopFilterResult.FILTER : EnvelopFilterResult.EXCLUDE_ALL;
+	}
 	boolean geometryMatches(Transaction tx, Node geomNode);
 
 }


### PR DESCRIPTION
Implemented a shortcut for the `spatial.intersects` procedure to improve performance.

The update bypasses the full geometry intersection check when the requested polygon is a rectangle (without hole) and the target geometry is entirely contained within the search window.
This optimization reduces unnecessary computations, enhancing the efficiency of spatial intersection operations.

**Test-Coverage**:

No new test was added, since the relevant code was already covered by existing tests