### PR TITLE
Refactor geometry addition methods to use `Map<String, Object>` for properties instead of `String[]` and `Object[]`.

### DIFF
--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/DefaultLayer.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/DefaultLayer.java
@@ -22,7 +22,6 @@ package org.neo4j.gis.spatial;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
@@ -70,33 +69,6 @@ public class DefaultLayer implements Constants, Layer, SpatialDataset {
 	@Override
 	public String getSignature() {
 		return "Layer(name='" + getName() + "', encoder=" + getGeometryEncoder().getSignature() + ")";
-	}
-
-	/**
-	 * Add the geometry encoded in the given Node. This causes the geometry to appear in the index.
-	 */
-	@Override
-	public SpatialDatabaseRecord add(Transaction tx, Node geomNode) {
-		Geometry geometry = getGeometryEncoder().decodeGeometry(geomNode);
-
-		// add BBOX to Node if it's missing
-		getGeometryEncoder().ensureIndexable(geometry, geomNode);
-
-		indexWriter.add(tx, geomNode);
-		return new SpatialDatabaseRecord(this, geomNode, geometry);
-	}
-
-	@Override
-	public int addAll(Transaction tx, List<Node> geomNodes) {
-		GeometryEncoder geometryEncoder = getGeometryEncoder();
-
-		for (Node geomNode : geomNodes) {
-			Geometry geometry = geometryEncoder.decodeGeometry(geomNode);
-			// add BBOX to Node if it's missing
-			geometryEncoder.encodeGeometry(tx, geometry, geomNode);
-		}
-		indexWriter.add(tx, geomNodes);
-		return geomNodes.size();
 	}
 
 	@Override

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/DynamicLayerConfig.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/DynamicLayerConfig.java
@@ -21,7 +21,6 @@ package org.neo4j.gis.spatial;
 
 import java.io.File;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.filter.text.cql2.CQLException;
@@ -88,18 +87,6 @@ public class DynamicLayerConfig implements Layer, Constants {
 
 	public String getQuery() {
 		return query;
-	}
-
-	@Override
-	public SpatialDatabaseRecord add(Transaction tx, Node geomNode) {
-		throw new SpatialDatabaseException(
-				"Cannot add nodes to dynamic layers, add the node to the base layer instead");
-	}
-
-	@Override
-	public int addAll(Transaction tx, List<Node> geomNodes) {
-		throw new SpatialDatabaseException(
-				"Cannot add nodes to dynamic layers, add the node to the base layer instead");
 	}
 
 	@Override

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/EditableLayer.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/EditableLayer.java
@@ -19,8 +19,12 @@
  */
 package org.neo4j.gis.spatial;
 
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.locationtech.jts.geom.Geometry;
+import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 
 /**
@@ -34,15 +38,34 @@ import org.neo4j.graphdb.Transaction;
 public interface EditableLayer extends Layer {
 
 	/**
+	 * This method adds existing geometries to the layer for indexing. After this method is called the geometry should
+	 * be searchable.
+	 *
+	 * @param geomNode the node containing the geometry to be added to the layer
+	 * @return SpatialDatabaseRecord representation of the geometry added to the database
+	 */
+	SpatialDatabaseRecord add(Transaction tx, Node geomNode);
+
+	/**
+	 * This method adds existing geometries to the layer for indexing in bulk. After this method is called the geometry
+	 * should be searchable.
+	 *
+	 * @param geomNodes the nodes containing the geometries to be added to the layer
+	 * @return the number of geometries added to the database
+	 */
+	int addAll(Transaction tx, List<Node> geomNodes);
+
+	/**
 	 * Add a new geometry to the layer. This will add the geometry to the index.
 	 */
 	SpatialDatabaseRecord add(Transaction tx, Geometry geometry);
 
 	/**
 	 * Add a new geometry to the layer. This will add the geometry to the index.
+	 *
+	 * @param properties the properties to attach to the newly created node
 	 */
-	//TODO: Rather use a HashMap of properties
-	SpatialDatabaseRecord add(Transaction tx, Geometry geometry, String[] fieldsName, Object[] fields);
+	SpatialDatabaseRecord add(Transaction tx, Geometry geometry, @Nullable Map<String, Object> properties);
 
 	/**
 	 * Delete the geometry identified by the passed node id. This might be as simple as deleting the

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/EditableLayerImpl.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/EditableLayerImpl.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.gis.spatial;
 
+import java.util.List;
+import java.util.Map;
 import org.locationtech.jts.geom.Geometry;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
@@ -26,19 +28,46 @@ import org.neo4j.graphdb.Transaction;
 public class EditableLayerImpl extends DefaultLayer implements EditableLayer {
 
 	/**
+	 * Add the geometry encoded in the given Node. This causes the geometry to appear in the index.
+	 */
+	@Override
+	public SpatialDatabaseRecord add(Transaction tx, Node geomNode) {
+		Geometry geometry = getGeometryEncoder().decodeGeometry(geomNode);
+
+		// add BBOX to Node if it's missing
+		getGeometryEncoder().ensureIndexable(geometry, geomNode);
+
+		indexWriter.add(tx, geomNode);
+		return new SpatialDatabaseRecord(this, geomNode, geometry);
+	}
+
+	@Override
+	public int addAll(Transaction tx, List<Node> geomNodes) {
+		GeometryEncoder geometryEncoder = getGeometryEncoder();
+
+		for (Node geomNode : geomNodes) {
+			Geometry geometry = geometryEncoder.decodeGeometry(geomNode);
+			// add BBOX to Node if it's missing
+			geometryEncoder.encodeGeometry(tx, geometry, geomNode);
+		}
+		indexWriter.add(tx, geomNodes);
+		return geomNodes.size();
+	}
+
+	/**
 	 * Add a geometry to this layer.
 	 */
 	@Override
 	public SpatialDatabaseRecord add(Transaction tx, Geometry geometry) {
-		return add(tx, geometry, null, null);
+		return add(tx, geometry, null);
 	}
 
 	/**
 	 * Add a geometry to this layer, including properties.
 	 */
 	@Override
-	public SpatialDatabaseRecord add(Transaction tx, Geometry geometry, String[] fieldsName, Object[] fields) {
-		Node geomNode = addGeomNode(tx, geometry, fieldsName, fields);
+	public SpatialDatabaseRecord add(Transaction tx, Geometry geometry, Map<String, Object> properties) {
+		Node geomNode = addGeomNode(tx, geometry, properties);
 		indexWriter.add(tx, geomNode);
 		return new SpatialDatabaseRecord(this, geomNode, geometry);
 	}
@@ -62,15 +91,10 @@ public class EditableLayerImpl extends DefaultLayer implements EditableLayer {
 		indexWriter.remove(tx, geomNodeId, deleteGeomNode, false);
 	}
 
-	protected Node addGeomNode(Transaction tx, Geometry geom, String[] fieldsName, Object[] fields) {
+	protected Node addGeomNode(Transaction tx, Geometry geom, Map<String, Object> properties) {
 		Node geomNode = tx.createNode();
-		// other properties
-		if (fieldsName != null) {
-			for (int i = 0; i < fieldsName.length; i++) {
-				if (fieldsName[i] != null && fields[i] != null) {
-					geomNode.setProperty(fieldsName[i], fields[i]);
-				}
-			}
+		if (properties != null) {
+			properties.forEach(geomNode::setProperty);
 		}
 		getGeometryEncoder().encodeGeometry(tx, geom, geomNode);
 

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/Layer.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/Layer.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.gis.spatial;
 
-import java.util.List;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.neo4j.gis.spatial.attributes.PropertyMappingManager;
@@ -55,24 +54,6 @@ public interface Layer {
 	 * @return the SpatialIndexReader used to perform searches on the data in the layer
 	 */
 	LayerIndexReader getIndex();
-
-	/**
-	 * This method adds existing geometries to the layer for indexing. After this method is called the geometry should
-	 * be searchable.
-	 *
-	 * @param geomNode the node containing the geometry to be added to the layer
-	 * @return SpatialDatabaseRecord representation of the geometry added to the database
-	 */
-	SpatialDatabaseRecord add(Transaction tx, Node geomNode);
-
-	/**
-	 * This method adds existing geometries to the layer for indexing in bulk. After this method is called the geometry
-	 * should be searchable.
-	 *
-	 * @param geomNodes the nodes containing the geometries to be added to the layer
-	 * @return the number of geometries added to the database
-	 */
-	int addAll(Transaction tx, List<Node> geomNodes);
 
 	GeometryFactory getGeometryFactory();
 

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/OrderedEditableLayer.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/OrderedEditableLayer.java
@@ -21,6 +21,7 @@ package org.neo4j.gis.spatial;
 
 import static org.neo4j.gis.spatial.utilities.TraverserFactory.createTraverserInBackwardsCompatibleWay;
 
+import java.util.Map;
 import org.locationtech.jts.geom.Geometry;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.Node;
@@ -51,8 +52,8 @@ public class OrderedEditableLayer extends EditableLayerImpl {
 	}
 
 	@Override
-	protected Node addGeomNode(Transaction tx, Geometry geom, String[] fieldsName, Object[] fields) {
-		Node geomNode = super.addGeomNode(tx, geom, fieldsName, fields);
+	protected Node addGeomNode(Transaction tx, Geometry geom, Map<String, Object> properties) {
+		Node geomNode = super.addGeomNode(tx, geom, properties);
 		Node layerNode = getLayerNode(tx);
 		if (previousGeomNode == null) {
 			TraversalDescription traversalDescription = new MonoDirectionalTraversalDescription()

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/SimplePointLayer.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/SimplePointLayer.java
@@ -20,6 +20,7 @@
 package org.neo4j.gis.spatial;
 
 import java.util.List;
+import java.util.Map;
 import org.locationtech.jts.geom.Coordinate;
 import org.neo4j.gis.spatial.pipes.GeoPipeFlow;
 import org.neo4j.gis.spatial.pipes.GeoPipeline;
@@ -31,19 +32,19 @@ public class SimplePointLayer extends EditableLayerImpl {
 	public static final int LIMIT_RESULTS = 100;
 
 	public SpatialDatabaseRecord add(Transaction tx, Coordinate coordinate) {
-		return add(tx, coordinate, null, null);
+		return add(tx, coordinate, null);
 	}
 
-	public SpatialDatabaseRecord add(Transaction tx, Coordinate coordinate, String[] fieldsName, Object[] fields) {
-		return add(tx, getGeometryFactory().createPoint(coordinate), fieldsName, fields);
+	public SpatialDatabaseRecord add(Transaction tx, Coordinate coordinate, Map<String, Object> properties) {
+		return add(tx, getGeometryFactory().createPoint(coordinate), properties);
 	}
 
 	public SpatialDatabaseRecord add(Transaction tx, double x, double y) {
-		return add(tx, new Coordinate(x, y), null, null);
+		return add(tx, new Coordinate(x, y), null);
 	}
 
-	public SpatialDatabaseRecord add(Transaction tx, double x, double y, String[] fieldsName, Object[] fields) {
-		return add(tx, new Coordinate(x, y), fieldsName, fields);
+	public SpatialDatabaseRecord add(Transaction tx, double x, double y, Map<String, Object> properties) {
+		return add(tx, new Coordinate(x, y), properties);
 	}
 
 	public static Integer getGeometryType() {

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/OsmAnalysisTest.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/OsmAnalysisTest.java
@@ -384,11 +384,14 @@ public class OsmAnalysisTest extends TestOSMImportBase {
 								l.add(tx, l.getGeometryFactory().createPoint(
 												new Coordinate((Double) changedNode.getProperty("lon"), (Double) changedNode
 														.getProperty("lat"))),
-										new String[]{"user_id", "user_name", "year", "month",
-												"dayOfMonth", "weekOfYear"},
-										new Object[]{user.internalId, user.name, c.get(Calendar.YEAR),
-												c.get(Calendar.MONTH),
-												c.get(Calendar.DAY_OF_MONTH), c.get(Calendar.WEEK_OF_YEAR)});
+										Map.of(
+												"user_id", user.internalId,
+												"user_name", user.name,
+												"year", c.get(Calendar.YEAR),
+												"month", c.get(Calendar.MONTH),
+												"dayOfMonth", c.get(Calendar.DAY_OF_MONTH),
+												"weekOfYear", c.get(Calendar.WEEK_OF_YEAR)
+										));
 							}
 						}
 					}

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/TestSimplePointLayer.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/TestSimplePointLayer.java
@@ -204,7 +204,7 @@ public class TestSimplePointLayer extends Neo4jTestCase {
 
 		Coordinate[] coords = makeCoordinateDataFromTextFile("NEO4J-SPATIAL.txt", testOrigin);
 		inTx(tx -> {
-			Layer layer = spatial.getLayer(tx, layerName);
+			EditableLayer layer = (EditableLayer) spatial.getLayer(tx, layerName);
 			for (Coordinate coordinate : coords) {
 				Node n = tx.createNode();
 				n.setProperty("x", coordinate.x);
@@ -226,7 +226,7 @@ public class TestSimplePointLayer extends Neo4jTestCase {
 
 		Coordinate[] coords = makeCoordinateDataFromTextFile("NEO4J-SPATIAL.txt", testOrigin);
 		inTx(tx -> {
-			Layer layer = spatial.getLayer(tx, layerName);
+			EditableLayer layer = (EditableLayer) spatial.getLayer(tx, layerName);
 			for (Coordinate coordinate : coords) {
 				Node n = tx.createNode();
 				n.setProperty("x", coordinate.x);
@@ -257,9 +257,9 @@ public class TestSimplePointLayer extends Neo4jTestCase {
 
 		Coordinate[] coords = makeCoordinateDataFromTextFile("NEO4J-SPATIAL.txt", testOrigin);
 		try (Transaction tx = db.beginTx()) {
-			Layer layerA = spatial.getLayer(tx, layerNameA);
-			Layer layerB = spatial.getLayer(tx, layerNameB);
-			Layer layerC = spatial.getLayer(tx, layerNameC);
+			EditableLayer layerA = (EditableLayer) spatial.getLayer(tx, layerNameA);
+			EditableLayer layerB = (EditableLayer) spatial.getLayer(tx, layerNameB);
+			EditableLayer layerC = (EditableLayer) spatial.getLayer(tx, layerNameC);
 			for (Coordinate coordinate : coords) {
 				Node n = tx.createNode();
 				n.setProperty("xa", coordinate.x);

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/pipes/GeoPipesDocTest.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/pipes/GeoPipesDocTest.java
@@ -32,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -941,10 +942,10 @@ public class GeoPipesDocTest extends AbstractJavaDocTestBase {
 			WKTReader reader = new WKTReader(boxesLayer.getGeometryFactory());
 			boxesLayer.add(tx,
 					reader.read("POLYGON ((12 26, 12 27, 13 27, 13 26, 12 26))"),
-					new String[]{"name"}, new Object[]{"A"});
+					Map.of("name", "A"));
 			boxesLayer.add(tx,
 					reader.read("POLYGON ((2 3, 2 5, 6 5, 6 3, 2 3))"),
-					new String[]{"name"}, new Object[]{"B"});
+					Map.of("name", "B"));
 
 			concaveLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "concave", null, null);
 			concaveLayer.setCoordinateReferenceSystem(tx, DefaultEngineeringCRS.GENERIC_2D);
@@ -963,15 +964,14 @@ public class GeoPipesDocTest extends AbstractJavaDocTestBase {
 			equalLayer.setCoordinateReferenceSystem(tx, DefaultEngineeringCRS.GENERIC_2D);
 			reader = new WKTReader(intersectionLayer.getGeometryFactory());
 			equalLayer.add(tx, reader.read("POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0))"),
-					new String[]{"id", "name"}, new Object[]{1, "equal"});
+					Map.of("id", 1,"name", "equal" ));
 			equalLayer.add(tx, reader.read("POLYGON ((0 0, 0.1 5, 5 5, 5 0, 0 0))"),
-					new String[]{"id", "name"}, new Object[]{2, "tolerance"});
+					Map.of("id", 2,"name", "tolerance" ));
 			equalLayer.add(tx, reader.read("POLYGON ((0 5, 5 5, 5 0, 0 0, 0 5))"),
-					new String[]{"id", "name"}, new Object[]{3,
-							"different order"});
+					Map.of("id", 3,"name", "different order" ));
 			equalLayer.add(tx,
 					reader.read("POLYGON ((0 0, 0 2, 0 4, 0 5, 5 5, 5 3, 5 2, 5 0, 0 0))"),
-					new String[]{"id", "name"}, new Object[]{4, "topo equal"});
+					Map.of("id", 4,"name", "topo equal" ));
 
 			linesLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "lines", null, null);
 			linesLayer.setCoordinateReferenceSystem(tx, DefaultEngineeringCRS.GENERIC_2D);


### PR DESCRIPTION
Refactors all geometry-addition methods to accept a `Map<String, Object>` of properties instead of parallel `String[]` and `Object[]` arrays, updating both the API surface and all callers (including tests and importers).

- Changed `EditableLayer` API and all implementations to use a single `Map<String, Object>` parameter.
- Updated calls in tests (`GeoPipesDocTest`, `TestSpatialUtils`, `TestSimplePointLayer`, `OsmAnalysisTest`) and in `ShapefileImporter` to build and pass a properties map.
- Removed now-unused overloads and cleaned up duplicate methods in `DefaultLayer` and `DynamicLayerConfig`.
