### PR TITLE
Refactor add methods in spatial index classes for improved efficiency and clarity

### DIFF
--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/index/ExplicitIndexBackedPointIndex.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/index/ExplicitIndexBackedPointIndex.java
@@ -79,17 +79,12 @@ public abstract class ExplicitIndexBackedPointIndex<E> implements LayerIndexRead
 		return new SearchRecords(layer, searchIndex(tx, filter));
 	}
 
-	@Override
-	public void add(Transaction tx, Node geomNode) {
-		index.add(geomNode, getIndexValueFor(tx, geomNode));
-	}
-
 	protected abstract E getIndexValueFor(Transaction tx, Node geomNode);
 
 	@Override
 	public void add(Transaction tx, List<Node> geomNodes) {
 		for (Node node : geomNodes) {
-			add(tx, node);
+			index.add(node, getIndexValueFor(tx, node));
 		}
 	}
 

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/index/SpatialIndexWriter.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/index/SpatialIndexWriter.java
@@ -27,7 +27,9 @@ import org.neo4j.graphdb.Transaction;
 
 public interface SpatialIndexWriter extends SpatialIndexReader {
 
-	void add(Transaction tx, Node geomNode);
+	default void add(Transaction tx, Node geomNode) {
+		add(tx, List.of(geomNode));
+	}
 
 	void add(Transaction tx, List<Node> geomNodes);
 


### PR DESCRIPTION
This PR refactors the `add` methods across spatial index classes to use batch operations, deduplicate inputs, and centralize single-node insertion via a default interface method. It also fixes exceptions when deleting nodes attached to multiple layers by properly handling incoming relationships.

- Introduced `add(Transaction, List<Node>)` as primary insertion endpoint and removed redundant single-node overrides.
- Enhanced bulk insertion in `RTreeIndex` with deduplication via `LinkedHashSet` and updated rebuild logic.
- Fixed relationship cleanup in `mergeTwoSubtrees` and `onIndexReference` to avoid orphaned or missing relationships.