### PR TITLE
Add support for layer read-only initialization and enforce write checks in EditableLayer methods

### DIFF
--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/DynamicLayer.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/DynamicLayer.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.gis.spatial;
 
+import static org.neo4j.gis.spatial.Constants.GTYPE_GEOMETRY;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -60,7 +62,7 @@ public class DynamicLayer extends EditableLayerImpl {
 			try (var relationships = getLayerNode(tx).getRelationships(Direction.OUTGOING,
 					SpatialRelationshipTypes.LAYER_CONFIG)) {
 				for (Relationship rel : relationships) {
-					DynamicLayerConfig config = new DynamicLayerConfig(this, rel.getEndNode());
+					DynamicLayerConfig config = new DynamicLayerConfig(this, rel.getEndNode(), isReadOnly());
 					layers.put(config.getName(), config);
 				}
 			}
@@ -69,6 +71,7 @@ public class DynamicLayer extends EditableLayerImpl {
 	}
 
 	protected boolean removeLayerConfig(Transaction tx, String name) {
+		checkWritable();
 		Layer layer = getLayerMap(tx).get(name);
 		if (layer instanceof DynamicLayerConfig) {
 			synchronized (this) {
@@ -161,6 +164,7 @@ public class DynamicLayer extends EditableLayerImpl {
 			return null;
 		}
 		synchronized (this) {
+			checkWritable();
 			DynamicLayerConfig config = new DynamicLayerConfig(tx, this, name, type, query);
 			layers = null;    // force recalculation of layers cache
 			return config;

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/EditableLayer.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/EditableLayer.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.locationtech.jts.geom.Geometry;
+import org.neo4j.gis.spatial.rtree.Listener;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 
@@ -66,6 +67,16 @@ public interface EditableLayer extends Layer {
 	 * @param properties the properties to attach to the newly created node
 	 */
 	SpatialDatabaseRecord add(Transaction tx, Geometry geometry, @Nullable Map<String, Object> properties);
+
+	/**
+	 * Delete the entire layer, including the index. The specific layer implementation will decide
+	 * if this method should delete also the geometry nodes indexed by this layer. Some
+	 * implementations have data that only has meaning within a layer, and so will be deleted.
+	 * Others are simply views onto other more complex data models and deleting the geometry nodes
+	 * might imply damage to the model. Keep this in mind when coding implementations of the Layer.
+	 */
+	void delete(Transaction tx, Listener monitor);
+
 
 	/**
 	 * Delete the geometry identified by the passed node id. This might be as simple as deleting the

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/OrderedEditableLayer.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/OrderedEditableLayer.java
@@ -53,6 +53,7 @@ public class OrderedEditableLayer extends EditableLayerImpl {
 
 	@Override
 	protected Node addGeomNode(Transaction tx, Geometry geom, Map<String, Object> properties) {
+		checkWritable();
 		Node geomNode = super.addGeomNode(tx, geom, properties);
 		Node layerNode = getLayerNode(tx);
 		if (previousGeomNode == null) {

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/ShapefileImporter.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/ShapefileImporter.java
@@ -103,7 +103,7 @@ public class ShapefileImporter implements Constants {
 		EditableLayerImpl layer;
 		try (Transaction tx = database.beginTx()) {
 			layer = (EditableLayerImpl) spatialDatabase.getOrCreateLayer(tx, layerName, WKBGeometryEncoder.class,
-					layerClass, null);
+					layerClass, null, false);
 			tx.commit();
 		}
 		return importFile(dataset, layer, charset);

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/SimplePointLayer.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/SimplePointLayer.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.gis.spatial;
 
+import static org.neo4j.gis.spatial.Constants.GTYPE_POINT;
+
 import java.util.List;
 import java.util.Map;
 import org.locationtech.jts.geom.Coordinate;

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/functions/SpatialFunctions.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/functions/SpatialFunctions.java
@@ -48,7 +48,7 @@ public class SpatialFunctions extends SpatialApiBase {
 			@Name(value = "layerName", description = "The name of the layer used to select the appropriate geometry encoder for extracting the Neo4j geometry.") String name,
 			@Name(value = "node", description = "An index node to extract the neo4j geometry from") Node node) {
 
-		Layer layer = getLayerOrThrow(tx, spatial(), name);
+		Layer layer = getLayerOrThrow(tx, spatial(), name, true);
 		GeometryResult result = new GeometryResult(
 				toNeo4jGeometry(layer, layer.getGeometryEncoder().decodeGeometry(node)));
 		return result.geometry;

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/index/ExplicitIndexBackedPointIndex.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/index/ExplicitIndexBackedPointIndex.java
@@ -61,7 +61,7 @@ public abstract class ExplicitIndexBackedPointIndex<E> implements LayerIndexRead
 	protected abstract String indexTypeName();
 
 	@Override
-	public void init(Transaction tx, IndexManager indexManager, Layer layer) {
+	public void init(Transaction tx, IndexManager indexManager, Layer layer, boolean readOnly) {
 		this.layer = layer;
 		String indexName = "_SpatialIndex_" + indexTypeName() + "_" + layer.getName();
 		Label label = Label.label("SpatialIndex_" + indexTypeName() + "_" + layer.getName());

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/index/LayerIndexReader.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/index/LayerIndexReader.java
@@ -33,7 +33,7 @@ public interface LayerIndexReader extends SpatialIndexReader {
 	 * @param indexManager for setting up index files on disk
 	 * @param layer        object containing and controlling this index
 	 */
-	void init(Transaction tx, IndexManager indexManager, Layer layer);
+	void init(Transaction tx, IndexManager indexManager, Layer layer, boolean readOnly);
 
 	Layer getLayer();
 

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/index/LayerRTreeIndex.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/index/LayerRTreeIndex.java
@@ -40,12 +40,8 @@ public class LayerRTreeIndex extends RTreeIndex implements LayerTreeIndexReader,
 	private Layer layer;
 
 	@Override
-	public void init(Transaction tx, IndexManager indexManager, Layer layer) {
-		init(tx, layer, 100);
-	}
-
-	public void init(Transaction tx, Layer layer, int maxNodeReferences) {
-		super.init(tx, layer.getLayerNode(tx), layer.getGeometryEncoder(), maxNodeReferences);
+	public void init(Transaction tx, IndexManager indexManager, Layer layer, boolean readOnly) {
+		super.init(tx, layer.getLayerNode(tx), layer.getGeometryEncoder(), 100, readOnly);
 		this.layer = layer;
 	}
 

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/indexfilter/LayerIndexReaderWrapper.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/indexfilter/LayerIndexReaderWrapper.java
@@ -51,7 +51,7 @@ public class LayerIndexReaderWrapper implements LayerIndexReader {
 	}
 
 	@Override
-	public void init(Transaction tx, IndexManager indexManager, Layer layer) {
+	public void init(Transaction tx, IndexManager indexManager, Layer layer, boolean readOnly) {
 		if (layer != getLayer()) {
 			throw new IllegalArgumentException("Cannot change layer associated with this index");
 		}

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/osm/OSMImporter.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/osm/OSMImporter.java
@@ -250,7 +250,7 @@ public class OSMImporter implements Constants {
 		OSMDataset dataset;
 		try (Transaction tx = beginTx(database)) {
 			layer = (OSMLayer) spatialDatabase.getOrCreateLayer(tx, layerName, OSMGeometryEncoder.class,
-					OSMLayer.class, null);
+					OSMLayer.class, null, false);
 			dataset = OSMDataset.withDatasetId(tx, layer, osm_dataset);
 			tx.commit();
 		}

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/osm/OSMLayer.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/osm/OSMLayer.java
@@ -19,12 +19,15 @@
  */
 package org.neo4j.gis.spatial.osm;
 
+import static org.neo4j.gis.spatial.Constants.GTYPE_GEOMETRY;
+import static org.neo4j.gis.spatial.Constants.GTYPE_LINESTRING;
+import static org.neo4j.gis.spatial.Constants.PROP_TYPE;
+
 import java.io.File;
 import java.util.HashMap;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.json.simple.JSONObject;
-import org.neo4j.gis.spatial.Constants;
 import org.neo4j.gis.spatial.DynamicLayer;
 import org.neo4j.gis.spatial.DynamicLayerConfig;
 import org.neo4j.gis.spatial.SpatialDatabaseService;
@@ -84,6 +87,7 @@ public class OSMLayer extends DynamicLayer {
 	}
 
 	public Node addWay(Transaction tx, Node way, boolean verifyGeom) {
+		checkWritable();
 		Relationship geomRel = way.getSingleRelationship(OSMRelation.GEOM, Direction.OUTGOING);
 		if (geomRel != null) {
 			Node geomNode = geomRel.getEndNode();
@@ -190,7 +194,7 @@ public class OSMLayer extends DynamicLayer {
 	 * @param value value to match on way tags
 	 */
 	public DynamicLayerConfig addSimpleDynamicLayer(Transaction tx, String key, String value) {
-		return addSimpleDynamicLayer(tx, key, value, Constants.GTYPE_LINESTRING);
+		return addSimpleDynamicLayer(tx, key, value, GTYPE_LINESTRING);
 	}
 
 	/**

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/osm/OSMLayerToShapefileExporter.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/osm/OSMLayerToShapefileExporter.java
@@ -65,7 +65,7 @@ public class OSMLayerToShapefileExporter {
 					new IndexManager((GraphDatabaseAPI) db, SecurityContext.AUTH_DISABLED));
 			OSMLayer layer;
 			try (Transaction tx = db.beginTx()) {
-				layer = (OSMLayer) spatial.getLayer(tx, osmdataset);
+				layer = (OSMLayer) spatial.getLayer(tx, osmdataset, false);
 			}
 			if (layer != null) {
 				ShapefileExporter exporter = new ShapefileExporter(db);

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/utilities/LayerUtilities.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/utilities/LayerUtilities.java
@@ -42,7 +42,12 @@ public class LayerUtilities implements Constants {
 	 * @return new layer instance from existing layer node
 	 */
 	@SuppressWarnings("unchecked")
-	public static Layer makeLayerFromNode(Transaction tx, IndexManager indexManager, Node layerNode) {
+	public static Layer makeLayerFromNode(
+			Transaction tx,
+			IndexManager indexManager,
+			Node layerNode,
+			boolean readOnly
+	) {
 		try {
 			String name = (String) layerNode.getProperty(PROP_LAYER);
 			if (name == null) {
@@ -57,7 +62,7 @@ public class LayerUtilities implements Constants {
 
 			Class<? extends Layer> layerClass =
 					className == null ? Layer.class : (Class<? extends Layer>) Class.forName(className);
-			return makeLayerInstance(tx, indexManager, name, layerNode, layerClass);
+			return makeLayerInstance(tx, indexManager, name, layerNode, layerClass, readOnly);
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
@@ -69,10 +74,15 @@ public class LayerUtilities implements Constants {
 	 *
 	 * @return new Layer instance based on newly created layer Node
 	 */
-	public static Layer makeLayerAndNode(Transaction tx, IndexManager indexManager, String name,
+	public static Layer makeLayerAndNode(
+			Transaction tx,
+			IndexManager indexManager,
+			String name,
 			Class<? extends GeometryEncoder> geometryEncoderClass,
 			Class<? extends Layer> layerClass,
-			Class<? extends LayerIndexReader> indexClass) {
+			Class<? extends LayerIndexReader> indexClass,
+			boolean readOnly
+	) {
 		try {
 			if (indexClass == null) {
 				indexClass = LayerRTreeIndex.class;
@@ -83,20 +93,26 @@ public class LayerUtilities implements Constants {
 			layerNode.setProperty(PROP_GEOMENCODER, geometryEncoderClass.getCanonicalName());
 			layerNode.setProperty(PROP_INDEX_CLASS, indexClass.getCanonicalName());
 			layerNode.setProperty(PROP_LAYER_CLASS, layerClass.getCanonicalName());
-			return makeLayerInstance(tx, indexManager, name, layerNode, layerClass);
+			return makeLayerInstance(tx, indexManager, name, layerNode, layerClass, false);
 		} catch (Exception e) {
 			throw new SpatialDatabaseException(e);
 		}
 	}
 
-	private static Layer makeLayerInstance(Transaction tx, IndexManager indexManager, String name, Node layerNode,
-			Class<? extends Layer> layerClass)
+	private static Layer makeLayerInstance(
+			Transaction tx,
+			IndexManager indexManager,
+			String name,
+			Node layerNode,
+			Class<? extends Layer> layerClass,
+			boolean readOnly
+	)
 			throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
 		if (layerClass == null) {
 			layerClass = Layer.class;
 		}
 		Layer layer = layerClass.getDeclaredConstructor().newInstance();
-		layer.initialize(tx, indexManager, name, layerNode);
+		layer.initialize(tx, indexManager, name, layerNode, readOnly);
 		return layer;
 	}
 

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/utilities/SpatialApiBase.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/utilities/SpatialApiBase.java
@@ -191,8 +191,9 @@ public class SpatialApiBase {
 		return toMap(toNeo4jGeometry(null, geometry));
 	}
 
-	protected static Layer getLayerOrThrow(Transaction tx, SpatialDatabaseService spatial, String name) {
-		EditableLayer layer = (EditableLayer) spatial.getLayer(tx, name);
+	protected static Layer getLayerOrThrow(Transaction tx, SpatialDatabaseService spatial, String name,
+			boolean readOnly) {
+		EditableLayer layer = (EditableLayer) spatial.getLayer(tx, name, readOnly);
 		if (layer != null) {
 			return layer;
 		}

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/FakeIndex.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/FakeIndex.java
@@ -41,11 +41,11 @@ import org.neo4j.graphdb.Transaction;
 public class FakeIndex implements LayerIndexReader, Constants {
 
 	public FakeIndex(Layer layer, IndexManager indexManager) {
-		init(null, indexManager, layer);
+		init(null, indexManager, layer, true);
 	}
 
 	@Override
-	public void init(Transaction ignored, IndexManager indexManager, Layer layer) {
+	public void init(Transaction ignored, IndexManager indexManager, Layer layer, boolean readOnly) {
 		this.layer = layer;
 	}
 

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/LayerSignatureTest.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/LayerSignatureTest.java
@@ -70,13 +70,13 @@ public class LayerSignatureTest extends Neo4jTestCase implements Constants {
 	@Test
 	public void testWKBLayer() {
 		testLayerSignature("EditableLayer(name='test', encoder=WKBGeometryEncoder(geom='wkb', bbox='bbox'))",
-				tx -> spatial.getOrCreateEditableLayer(tx, "test", "wkb", "wkb", null));
+				tx -> spatial.getOrCreateEditableLayer(tx, "test", "wkb", "wkb", null, true));
 	}
 
 	@Test
 	public void testWKTLayer() {
 		testLayerSignature("EditableLayer(name='test', encoder=WKTGeometryEncoder(geom='wkt', bbox='bbox'))",
-				tx -> spatial.getOrCreateEditableLayer(tx, "test", "wkt", "wkt", null));
+				tx -> spatial.getOrCreateEditableLayer(tx, "test", "wkt", "wkt", null, true));
 	}
 
 	private Layer testLayerSignature(String signature, Function<Transaction, Layer> layerMaker) {
@@ -100,7 +100,7 @@ public class LayerSignatureTest extends Neo4jTestCase implements Constants {
 	public void testDynamicLayer() {
 		Layer layer = testLayerSignature(
 				"EditableLayer(name='test', encoder=WKTGeometryEncoder(geom='wkt', bbox='bbox'))",
-				tx -> spatial.getOrCreateEditableLayer(tx, "test", "wkt", "wkt", null));
+				tx -> spatial.getOrCreateEditableLayer(tx, "test", "wkt", "wkt", null, false));
 		inTx(tx -> {
 			DynamicLayer dynamic = spatial.asDynamicLayer(tx, layer);
 			assertEquals("EditableLayer(name='test', encoder=WKTGeometryEncoder(geom='wkt', bbox='bbox'))",

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/Neo4jTestUtils.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/Neo4jTestUtils.java
@@ -54,7 +54,7 @@ public class Neo4jTestUtils {
 		try (Transaction tx = db.beginTx()) {
 			SpatialDatabaseService spatial = new SpatialDatabaseService(
 					new IndexManager((GraphDatabaseAPI) db, SecurityContext.AUTH_DISABLED));
-			Layer layer = spatial.getLayer(tx, layerName);
+			Layer layer = spatial.getLayer(tx, layerName, true);
 			RTreeIndex index = (RTreeIndex) layer.getIndex();
 			printTree(index.getIndexRoot(tx), 0);
 			tx.commit();

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/OsmAnalysisTest.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/OsmAnalysisTest.java
@@ -121,7 +121,7 @@ public class OsmAnalysisTest extends TestOSMImportBase {
 				new IndexManager((GraphDatabaseAPI) graphDb(), SecurityContext.AUTH_DISABLED));
 		boolean alreadyImported;
 		try (Transaction tx = graphDb().beginTx()) {
-			alreadyImported = spatial.getLayer(tx, osm) != null;
+			alreadyImported = spatial.getLayer(tx, osm, true) != null;
 			tx.commit();
 		}
 		if (!alreadyImported) {
@@ -139,7 +139,7 @@ public class OsmAnalysisTest extends TestOSMImportBase {
 		long latestTimestamp = 0L;
 		long firstTimestamp = Long.MAX_VALUE;
 		try (Transaction tx = graphDb().beginTx()) {
-			OSMLayer layer = (OSMLayer) spatial.getLayer(tx, osm);
+			OSMLayer layer = (OSMLayer) spatial.getLayer(tx, osm, true);
 			OSMDataset dataset = OSMDataset.fromLayer(tx, layer);
 
 			for (Node cNode : dataset.getAllChangesetNodes(tx)) {
@@ -164,7 +164,7 @@ public class OsmAnalysisTest extends TestOSMImportBase {
 		}
 		SortedSet<User> topTen = getTopTen(userIndex);
 		try (Transaction tx = graphDb().beginTx()) {
-			OSMLayer layer = (OSMLayer) spatial.getLayer(tx, osm);
+			OSMLayer layer = (OSMLayer) spatial.getLayer(tx, osm, false);
 			Date latest = new Date(latestTimestamp);
 			Calendar time = Calendar.getInstance();
 			time.setTime(latest);

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/RTreeBulkInsertTest.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/RTreeBulkInsertTest.java
@@ -179,7 +179,8 @@ public class RTreeBulkInsertTest {
 		CoordinateReferenceSystem crs = DefaultEngineeringCRS.GENERIC_2D;
 		try (Transaction tx = db.beginTx()) {
 			SpatialDatabaseService sdbs = spatial();
-			EditableLayer layer = sdbs.getOrCreateSimplePointLayer(tx, name, index, xProperty, yProperty, null);
+			EditableLayer layer = sdbs.getOrCreateSimplePointLayer(tx, name, index, xProperty, yProperty, null,
+					false);
 			layer.setCoordinateReferenceSystem(tx, crs);
 			tx.commit();
 			return layer;
@@ -312,7 +313,7 @@ public class RTreeBulkInsertTest {
 		@Override
 		public EditableLayer setupLayer(Transaction tx) {
 			this.nodes = setup(name, "geohash", config.width);
-			this.layer = (EditableLayer) spatial().getLayer(tx, "Coordinates");
+			this.layer = (EditableLayer) spatial().getLayer(tx, "Coordinates", false);
 			return layer;
 		}
 
@@ -361,7 +362,7 @@ public class RTreeBulkInsertTest {
 		@Override
 		public EditableLayer setupLayer(Transaction tx) {
 			this.nodes = setup(name, "zorder", config.width);
-			this.layer = (EditableLayer) spatial().getLayer(tx, "Coordinates");
+			this.layer = (EditableLayer) spatial().getLayer(tx, "Coordinates", false);
 			return layer;
 		}
 
@@ -410,7 +411,7 @@ public class RTreeBulkInsertTest {
 		@Override
 		public EditableLayer setupLayer(Transaction tx) {
 			this.nodes = setup(name, "hilbert", config.width);
-			this.layer = (EditableLayer) spatial().getLayer(tx, "Coordinates");
+			this.layer = (EditableLayer) spatial().getLayer(tx, "Coordinates", false);
 			return layer;
 		}
 
@@ -473,7 +474,7 @@ public class RTreeBulkInsertTest {
 		@Override
 		public EditableLayer setupLayer(Transaction tx) {
 			this.nodes = setup(name, "rtree", config.width);
-			this.layer = (EditableLayer) spatial.getLayer(tx, name);
+			this.layer = (EditableLayer) spatial.getLayer(tx, name, false);
 			layer.getIndex().configure(Map.of(
 					RTreeIndex.KEY_SPLIT, splitMode,
 					RTreeIndex.KEY_MAX_NODE_REFERENCES, maxNodeReferences,
@@ -1201,7 +1202,7 @@ public class RTreeBulkInsertTest {
 			try (Transaction tx = db.beginTx()) {
 
 				RTreeIndex rtree = new RTreeIndex();
-				rtree.init(tx, tx.createNode(), encoder, DEFAULT_MAX_NODE_REFERENCES);
+				rtree.init(tx, tx.createNode(), encoder, DEFAULT_MAX_NODE_REFERENCES, true);
 				List<Node> coords = new ArrayList<>(i);
 				for (int j = 0; j < i; j++) {
 					Node n = tx.createNode(Label.label("Coordinate"));
@@ -1245,7 +1246,8 @@ public class RTreeBulkInsertTest {
 			System.out.println("BulkLoadingTestRun " + j);
 			try (Transaction tx = db.beginTx()) {
 
-				EditableLayer layer = sdbs.getOrCreateSimplePointLayer(tx, "BulkLoader", "rtree", "lon", "lat", null);
+				EditableLayer layer = sdbs.getOrCreateSimplePointLayer(tx, "BulkLoader", "rtree", "lon", "lat", null,
+						false);
 				List<Node> coords = new ArrayList<>(N);
 				for (int i = 0; i < N; i++) {
 					Node n = tx.createNode(Label.label("Coordinate"));
@@ -1282,7 +1284,7 @@ public class RTreeBulkInsertTest {
 		}
 
 		try (Transaction tx = db.beginTx()) {
-			Layer layer = sdbs.getLayer(tx, "BulkLoader");
+			Layer layer = sdbs.getLayer(tx, "BulkLoader", false);
 			RTreeIndex rtree = (RTreeIndex) layer.getIndex();
 
 			Node root = rtree.getIndexRoot(tx);

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/SpatialIndexPerformanceProxy.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/SpatialIndexPerformanceProxy.java
@@ -43,7 +43,7 @@ public class SpatialIndexPerformanceProxy implements LayerIndexReader {
 	}
 
 	@Override
-	public void init(Transaction tx, IndexManager indexManager, Layer layer) {
+	public void init(Transaction tx, IndexManager indexManager, Layer layer, boolean readOnly) {
 		if (layer != getLayer()) {
 			throw new IllegalArgumentException("Cannot change layer associated with this index");
 		}

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/TestDynamicLayers.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/TestDynamicLayers.java
@@ -73,7 +73,7 @@ public class TestDynamicLayers extends Neo4jTestCase implements Constants {
 		try (Transaction tx = graphDb().beginTx()) {
 			SpatialDatabaseService spatial = new SpatialDatabaseService(
 					new IndexManager((GraphDatabaseAPI) graphDb(), SecurityContext.AUTH_DISABLED));
-			DynamicLayer shpLayer = spatial.asDynamicLayer(tx, spatial.getLayer(tx, shpFile));
+			DynamicLayer shpLayer = spatial.asDynamicLayer(tx, spatial.getLayer(tx, shpFile, false));
 			layers.add(shpLayer.addLayerConfig(tx, "CQL0-highway", GTYPE_GEOMETRY, "highway is not null"));
 			layers.add(shpLayer.addLayerConfig(tx, "CQL1-highway", GTYPE_POINT,
 					"geometryType(the_geom) = 'MultiLineString'"));
@@ -131,7 +131,7 @@ public class TestDynamicLayers extends Neo4jTestCase implements Constants {
 		try (Transaction tx = graphDb().beginTx()) {
 			SpatialDatabaseService spatial = new SpatialDatabaseService(
 					new IndexManager((GraphDatabaseAPI) graphDb(), SecurityContext.AUTH_DISABLED));
-			OSMLayer osmLayer = (OSMLayer) spatial.getLayer(tx, osmFile);
+			OSMLayer osmLayer = (OSMLayer) spatial.getLayer(tx, osmFile, false);
 			LinearRing ring = osmLayer.getGeometryFactory().createLinearRing(
 					new Coordinate[]{new Coordinate(bbox.getMinX(), bbox.getMinY()),
 							new Coordinate(bbox.getMinX(), bbox.getMaxY()),
@@ -288,7 +288,7 @@ public class TestDynamicLayers extends Neo4jTestCase implements Constants {
 				new IndexManager((GraphDatabaseAPI) graphDb(), SecurityContext.AUTH_DISABLED));
 		Layer layer;
 		try (Transaction tx = graphDb().beginTx()) {
-			layer = spatial.getLayer(tx, layerName);
+			layer = spatial.getLayer(tx, layerName, true);
 		}
 		assertNotNull(layer.getIndex(), "Layer index should not be null");
 		Envelope bbox;

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/TestIntersectsPathQueries.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/TestIntersectsPathQueries.java
@@ -230,7 +230,7 @@ public class TestIntersectsPathQueries {
 						System.out.println("\t" + name);
 					}
 					//OSMLayer layer = (OSMLayer) spatial.getOrCreateLayer(layerName, OSMGeometryEncoder.class, OSMLayer.class);
-					Layer layer = spatial.getLayer(tx, layerName);
+					Layer layer = spatial.getLayer(tx, layerName, true);
 					assertNotNull(layer.getIndex(), "Layer index should not be null");
 					assertNotNull(layer.getIndex().getBoundingBox(tx), "Layer index envelope should not be null");
 					Envelope bbox = Utilities.fromNeo4jToJts(layer.getIndex().getBoundingBox(tx));
@@ -268,7 +268,7 @@ public class TestIntersectsPathQueries {
 								+ coordinates.get(coordinates.size() - 1));
 				performance = new Performance("search points");
 				try (Transaction tx = graphDb.beginTx()) {
-					Layer layer = spatial.getLayer(tx, layerName);
+					Layer layer = spatial.getLayer(tx, layerName, true);
 					for (Coordinate coordinate : coordinates) {
 						List<Node> res = GeoPipeline.startNearestNeighborLatLonSearch(tx, layer, coordinate,
 										distanceInKm)
@@ -307,7 +307,7 @@ public class TestIntersectsPathQueries {
 					System.out.println("Searching for geometries near Geometry: " + gname);
 					performance = new Performance(gname);
 					try (Transaction tx = graphDb.beginTx()) {
-						Layer layer = spatial.getLayer(tx, layerName);
+						Layer layer = spatial.getLayer(tx, layerName, true);
 						List<Node> res = runSearch(GeoPipeline.startIntersectSearch(tx, layer, geometry), true);
 						performance.stop(res);
 						performances.put(performance.name, performance);

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/TestOSMImportBase.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/TestOSMImportBase.java
@@ -66,7 +66,7 @@ public class TestOSMImportBase extends Neo4jTestCase {
 			SpatialDatabaseService spatial = new SpatialDatabaseService(
 					new IndexManager((GraphDatabaseAPI) db, SecurityContext.AUTH_DISABLED));
 			OSMLayer layer = (OSMLayer) spatial.getOrCreateLayer(tx, layerName, OSMGeometryEncoder.class,
-					OSMLayer.class, null);
+					OSMLayer.class, null, true);
 			Assertions.assertNotNull(layer.getIndex(), "OSM Layer index should not be null");
 			Assertions.assertNotNull(layer.getIndex().getBoundingBox(tx),
 					"OSM Layer index envelope should not be null");

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/TestRemove.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/TestRemove.java
@@ -46,21 +46,23 @@ public class TestRemove extends Neo4jTestCase {
 		String[] ids = new String[rtreeMaxNodeReferences + 1];
 
 		try (Transaction tx = graphDb().beginTx()) {
-			EditableLayer layer = (EditableLayer) spatial.getLayer(tx, layerName);
+			EditableLayer layer = (EditableLayer) spatial.getLayer(tx, layerName, false);
 			GeometryFactory geomFactory = layer.getGeometryFactory();
 			for (int i = 0; i < ids.length; i++) {
 				ids[i] = layer.add(tx, geomFactory.createPoint(new Coordinate(i, i))).getNodeId();
 			}
+			layer.finalizeTransaction(tx);
 			tx.commit();
 		}
 
 		Neo4jTestUtils.debugIndexTree(graphDb(), layerName);
 
 		try (Transaction tx = graphDb().beginTx()) {
-			EditableLayer layer = (EditableLayer) spatial.getLayer(tx, layerName);
+			EditableLayer layer = (EditableLayer) spatial.getLayer(tx, layerName, false);
 			for (String id : ids) {
 				layer.delete(tx, id);
 			}
+			layer.finalizeTransaction(tx);
 			tx.commit();
 		}
 

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/TestSpatial.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/TestSpatial.java
@@ -207,7 +207,7 @@ public class TestSpatial extends Neo4jTestCase {
 		try (Transaction tx = graphDb().beginTx()) {
 			SpatialDatabaseService spatial = new SpatialDatabaseService(
 					new IndexManager((GraphDatabaseAPI) graphDb(), SecurityContext.AUTH_DISABLED));
-			Layer layer = spatial.getLayer(tx, layerName);
+			Layer layer = spatial.getLayer(tx, layerName, true);
 			if (layer != null && layer.getIndex() != null) {
 				count = layer.getIndex().count(tx);
 			}
@@ -263,7 +263,7 @@ public class TestSpatial extends Neo4jTestCase {
 		SpatialDatabaseService spatial = new SpatialDatabaseService(
 				new IndexManager((GraphDatabaseAPI) graphDb(), SecurityContext.AUTH_DISABLED));
 		try (Transaction tx = graphDb().beginTx()) {
-			Layer layer = spatial.getLayer(tx, layerName);
+			Layer layer = spatial.getLayer(tx, layerName, true);
 			if (layer == null || layer.getIndex() == null || layer.getIndex().count(tx) < 1) {
 				fail("Layer not loaded: " + layerName);
 			}

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/TestsForDocs.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/TestsForDocs.java
@@ -90,7 +90,7 @@ public class TestsForDocs {
 		SpatialDatabaseService spatial = new SpatialDatabaseService(
 				new IndexManager((GraphDatabaseAPI) graphDb, SecurityContext.AUTH_DISABLED));
 		try (Transaction tx = graphDb.beginTx()) {
-			Layer layer = spatial.getLayer(tx, layerName);
+			Layer layer = spatial.getLayer(tx, layerName, true);
 			if (layer.getIndex().count(tx) < 1) {
 				System.out.println("Warning: index count zero: " + layer.getName());
 			}
@@ -102,7 +102,7 @@ public class TestsForDocs {
 		SimpleFeatureCollection features = store.getFeatureSource(layerName).getFeatures();
 		System.out.println("Layer '" + layerName + "' has " + features.size() + " features");
 		try (Transaction tx = graphDb.beginTx()) {
-			Layer layer = spatial.getLayer(tx, layerName);
+			Layer layer = spatial.getLayer(tx, layerName, true);
 			assertEquals(layer.getIndex().count(tx), features.size(),
 					"FeatureCollection.size for layer '" + layer.getName() + "' not the same as index count");
 			if (layer instanceof OSMLayer) {
@@ -161,7 +161,7 @@ public class TestsForDocs {
 		SpatialDatabaseService spatial = new SpatialDatabaseService(
 				new IndexManager((GraphDatabaseAPI) graphDb, SecurityContext.AUTH_DISABLED));
 		try (Transaction tx = database.beginTx()) {
-			Layer layer = spatial.getLayer(tx, "map.osm");
+			Layer layer = spatial.getLayer(tx, "map.osm", true);
 			LayerIndexReader spatialIndex = layer.getIndex();
 			System.out.println("Have " + spatialIndex.count(tx) + " geometries in " + spatialIndex.getBoundingBox(tx));
 
@@ -201,9 +201,10 @@ public class TestsForDocs {
 				new IndexManager((GraphDatabaseAPI) graphDb, SecurityContext.AUTH_DISABLED));
 		String wayLayerName;
 		try (Transaction tx = database.beginTx()) {
-			OSMLayer layer = (OSMLayer) spatial.getLayer(tx, "map.osm");
+			OSMLayer layer = (OSMLayer) spatial.getLayer(tx, "map.osm", false);
 			DynamicLayerConfig wayLayer = layer.addSimpleDynamicLayer(tx, Constants.GTYPE_LINESTRING);
 			wayLayerName = wayLayer.getName();
+			layer.finalizeTransaction(tx);
 			tx.commit();
 		}
 		ShapefileExporter shpExporter = new ShapefileExporter(database);
@@ -222,7 +223,7 @@ public class TestsForDocs {
 		Envelope bbox = new Envelope(12.94, 12.96, 56.04, 56.06);
 		List<SpatialDatabaseRecord> results;
 		try (Transaction tx = database.beginTx()) {
-			Layer layer = spatial.getLayer(tx, "map.osm");
+			Layer layer = spatial.getLayer(tx, "map.osm", true);
 			LayerIndexReader spatialIndex = layer.getIndex();
 			System.out.println("Have " + spatialIndex.count(tx) + " geometries in " + spatialIndex.getBoundingBox(tx));
 

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/index/LayerIndexTestBase.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/index/LayerIndexTestBase.java
@@ -87,7 +87,7 @@ public abstract class LayerIndexTestBase {
 		Layer layer = mockLayer();
 		LayerIndexReader index = makeIndex();
 		try (Transaction tx = graph.beginTx()) {
-			index.init(tx, spatial.indexManager, layer);
+			index.init(tx, spatial.indexManager, layer, false);
 			tx.commit();
 		}
 		when(layer.getIndex()).thenReturn(index);
@@ -144,8 +144,8 @@ public abstract class LayerIndexTestBase {
 		LayerIndexReader index = layer.getIndex();
 		try (Transaction tx = graph.beginTx()) {
 			assertThat("Should find the same index", index.getLayer().getName(),
-					equalTo(spatial.getLayer(tx, "test").getName()));
-			assertThat("Index should be of right type", spatial.getLayer(tx, "test").getIndex().getClass(),
+					equalTo(spatial.getLayer(tx, "test", true).getName()));
+			assertThat("Index should be of right type", spatial.getLayer(tx, "test", true).getIndex().getClass(),
 					equalTo(getIndexClass()));
 		}
 	}
@@ -156,13 +156,13 @@ public abstract class LayerIndexTestBase {
 		LayerIndexReader index = layer.getIndex();
 		try (Transaction tx = graph.beginTx()) {
 			assertThat("Should find the same index", index.getLayer().getName(),
-					equalTo(spatial.getLayer(tx, "test").getName()));
-			assertThat("Index should be of right type", spatial.getLayer(tx, "test").getIndex().getClass(),
+					equalTo(spatial.getLayer(tx, "test", true).getName()));
+			assertThat("Index should be of right type", spatial.getLayer(tx, "test", true).getIndex().getClass(),
 					equalTo(getIndexClass()));
 		}
 		try (Transaction tx = graph.beginTx()) {
-			layer.delete(tx, new NullListener());
-			layer = spatial.getLayer(tx, "test");
+			((SimplePointLayer)layer).delete(tx, new NullListener());
+			layer = spatial.getLayer(tx, "test", true);
 			tx.commit();
 		}
 		assertThat("Expected no layer to be found", layer, is(nullValue()));
@@ -170,7 +170,8 @@ public abstract class LayerIndexTestBase {
 
 	private SimplePointLayer makeTestPointLayer() {
 		try (Transaction tx = graph.beginTx()) {
-			SimplePointLayer layer = spatial.createPointLayer(tx, "test", getIndexClass(), getEncoderClass(), null);
+			SimplePointLayer layer = spatial.createPointLayer(tx, "test", getIndexClass(), getEncoderClass(), null
+			);
 			tx.commit();
 			return layer;
 		}

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/pipes/GeoPipesDocTest.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/pipes/GeoPipesDocTest.java
@@ -934,9 +934,9 @@ public class GeoPipesDocTest extends AbstractJavaDocTestBase {
 
 		try (Transaction tx = db.beginTx()) {
 			loadTestOsmData("two-street.osm", 100);
-			osmLayer = spatial.getLayer(tx, "two-street.osm");
+			osmLayer = spatial.getLayer(tx, "two-street.osm", false);
 
-			boxesLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "boxes", null, null);
+			boxesLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "boxes", null, null, false);
 			boxesLayer.setExtraPropertyNames(new String[]{"name"}, tx);
 			boxesLayer.setCoordinateReferenceSystem(tx, DefaultEngineeringCRS.GENERIC_2D);
 			WKTReader reader = new WKTReader(boxesLayer.getGeometryFactory());
@@ -947,19 +947,20 @@ public class GeoPipesDocTest extends AbstractJavaDocTestBase {
 					reader.read("POLYGON ((2 3, 2 5, 6 5, 6 3, 2 3))"),
 					Map.of("name", "B"));
 
-			concaveLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "concave", null, null);
+			concaveLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "concave", null, null, false);
 			concaveLayer.setCoordinateReferenceSystem(tx, DefaultEngineeringCRS.GENERIC_2D);
 			reader = new WKTReader(concaveLayer.getGeometryFactory());
 			concaveLayer.add(tx, reader.read("POLYGON ((0 0, 2 5, 0 10, 10 10, 10 0, 0 0))"));
 
-			intersectionLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "intersection", null, null);
+			intersectionLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "intersection", null, null,
+					false);
 			intersectionLayer.setCoordinateReferenceSystem(tx, DefaultEngineeringCRS.GENERIC_2D);
 			reader = new WKTReader(intersectionLayer.getGeometryFactory());
 			intersectionLayer.add(tx, reader.read("POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0))"));
 			intersectionLayer.add(tx, reader.read("POLYGON ((4 4, 4 10, 10 10, 10 4, 4 4))"));
 			intersectionLayer.add(tx, reader.read("POLYGON ((2 2, 2 6, 6 6, 6 2, 2 2))"));
 
-			equalLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "equal", null, null);
+			equalLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "equal", null, null, false);
 			equalLayer.setExtraPropertyNames(new String[]{"id", "name"}, tx);
 			equalLayer.setCoordinateReferenceSystem(tx, DefaultEngineeringCRS.GENERIC_2D);
 			reader = new WKTReader(intersectionLayer.getGeometryFactory());
@@ -973,7 +974,7 @@ public class GeoPipesDocTest extends AbstractJavaDocTestBase {
 					reader.read("POLYGON ((0 0, 0 2, 0 4, 0 5, 5 5, 5 3, 5 2, 5 0, 0 0))"),
 					Map.of("id", 4,"name", "topo equal" ));
 
-			linesLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "lines", null, null);
+			linesLayer = (EditableLayerImpl) spatial.getOrCreateEditableLayer(tx, "lines", null, null, false);
 			linesLayer.setCoordinateReferenceSystem(tx, DefaultEngineeringCRS.GENERIC_2D);
 			reader = new WKTReader(intersectionLayer.getGeometryFactory());
 			linesLayer.add(tx, reader.read("LINESTRING (12 26, 15 27, 18 32, 20 38, 23 34)"));

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/pipes/GeoPipesPerformanceTest.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/pipes/GeoPipesPerformanceTest.java
@@ -61,6 +61,7 @@ public class GeoPipesPerformanceTest extends Neo4jTestCase {
 				SpatialDatabaseRecord record = layer.add(tx, x, y);
 				record.getGeomNode().setProperty("name", name);
 			}
+			layer.finalizeTransaction(tx);
 			tx.commit();
 			System.out.println("Finished writing " + records + " point records to database");
 		} catch (Exception e) {
@@ -101,7 +102,7 @@ public class GeoPipesPerformanceTest extends Neo4jTestCase {
 		SpatialDatabaseService spatial = new SpatialDatabaseService(
 				new IndexManager((GraphDatabaseAPI) graphDb(), SecurityContext.AUTH_DISABLED));
 		try (Transaction tx = graphDb().beginTx()) {
-			Layer layer = spatial.getLayer(tx, "GeoPipesPerformanceTest");
+			Layer layer = spatial.getLayer(tx, "GeoPipesPerformanceTest", true);
 			// String[] keys = {"id","name","address","city","state","zip"};
 			String[] keys = {"id", "name"};
 			Coordinate loc = new Coordinate(15.0, 15.0);
@@ -148,7 +149,7 @@ public class GeoPipesPerformanceTest extends Neo4jTestCase {
 		SpatialDatabaseService spatial = new SpatialDatabaseService(
 				new IndexManager((GraphDatabaseAPI) graphDb(), SecurityContext.AUTH_DISABLED));
 		try (Transaction tx = graphDb().beginTx()) {
-			Layer layer = spatial.getLayer(tx, "GeoPipesPerformanceTest");
+			Layer layer = spatial.getLayer(tx, "GeoPipesPerformanceTest", true);
 			// String[] keys = {"id","name","address","city","state","zip"};
 			String[] keys = {"id", "name"};
 			Coordinate loc = new Coordinate(15.0, 15.0);

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/procedures/SpatialProceduresTest.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/procedures/SpatialProceduresTest.java
@@ -101,7 +101,8 @@ public class SpatialProceduresTest extends AbstractApiTest {
 			});
 			fail("Expected an exception containing '" + error + "', but no exception was thrown");
 		} catch (Exception e) {
-			assertTrue(e.getMessage().contains(error));
+			Assertions.assertThat(e.getMessage())
+					.contains(error);
 		}
 	}
 
@@ -155,10 +156,10 @@ public class SpatialProceduresTest extends AbstractApiTest {
 			int index) {
 		return switch (index % 3) {
 			case 0 -> spatial.getOrCreateSimplePointLayer(tx, name, SpatialDatabaseService.INDEX_TYPE_RTREE, "x", "y",
-					null);
+					null, false);
 			case 1 -> spatial.getOrCreateNativePointLayer(tx, name, SpatialDatabaseService.INDEX_TYPE_RTREE, "location",
-					null);
-			default -> spatial.getOrCreateDefaultLayer(tx, name, null);
+					null, false);
+			default -> spatial.getOrCreateDefaultLayer(tx, name, null, false);
 		};
 	}
 
@@ -405,7 +406,7 @@ public class SpatialProceduresTest extends AbstractApiTest {
 					(r) -> assertEquals("geom", (dump((Node) r.get("node"))).getProperty("layer")));
 			fail("Expected exception to be thrown");
 		} catch (Exception e) {
-			assertTrue(e.getMessage().contains("Cannot create existing layer"));
+			Assertions.assertThat(e.getMessage()).contains("Layer already exists: 'geom'");
 		}
 	}
 
@@ -417,7 +418,7 @@ public class SpatialProceduresTest extends AbstractApiTest {
 					(r) -> assertEquals("geom", (dump((Node) r.get("node"))).getProperty("layer")));
 			fail("Expected exception to be thrown");
 		} catch (Exception e) {
-			assertTrue(e.getMessage().contains("Cannot create existing layer"));
+			Assertions.assertThat(e.getMessage()).contains("Layer already exists: 'geom'");
 		}
 	}
 

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/rtree/RTreeTests.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/rtree/RTreeTests.java
@@ -112,7 +112,7 @@ public class RTreeTests {
 		try (Transaction tx = db.beginTx()) {
 			RTreeIndex.NodeWithEnvelope rootNode = new RTreeIndex.NodeWithEnvelope(tx.createNode(),
 					new Envelope(min, max));
-			TestRTreeIndex.setIndexNodeEnvelope(rootNode);
+			rtree.setIndexNodeEnvelope(rootNode);
 			ArrayList<RTreeIndex.NodeWithEnvelope> parents = new ArrayList<>();
 			ArrayList<RTreeIndex.NodeWithEnvelope> children = new ArrayList<>();
 			parents.add(rootNode);
@@ -125,7 +125,7 @@ public class RTreeTests {
 							makeEnvelope(parent.envelope, 0.5, 0.0, 1.0)
 					};
 					for (Envelope env : envs) {
-						RTreeIndex.NodeWithEnvelope child = TestRTreeIndex.makeChildIndexNode(tx, parent, env);
+						RTreeIndex.NodeWithEnvelope child = rtree.makeChildIndexNode(tx, parent, env);
 						children.add(child);
 					}
 				}

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/rtree/TestRTreeIndex.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/rtree/TestRTreeIndex.java
@@ -27,10 +27,10 @@ public class TestRTreeIndex extends RTreeIndex {
 
 	// TODO: Rather pass tx into init after construction (bad pattern to pass tx to constructor, as if it will be saved)
 	public TestRTreeIndex(Transaction tx) {
-		init(tx, tx.createNode(), new SimplePointEncoder(), DEFAULT_MAX_NODE_REFERENCES);
+		init(tx, tx.createNode(), new SimplePointEncoder(), DEFAULT_MAX_NODE_REFERENCES, false);
 	}
 
-	public static RTreeIndex.NodeWithEnvelope makeChildIndexNode(Transaction tx, NodeWithEnvelope parent,
+	public RTreeIndex.NodeWithEnvelope makeChildIndexNode(Transaction tx, NodeWithEnvelope parent,
 			Envelope bbox) {
 		Node indexNode = tx.createNode();
 		setIndexNodeEnvelope(indexNode, bbox);
@@ -40,7 +40,7 @@ public class TestRTreeIndex extends RTreeIndex {
 		return new NodeWithEnvelope(indexNode, bbox);
 	}
 
-	public static void setIndexNodeEnvelope(NodeWithEnvelope indexNode) {
+	public void setIndexNodeEnvelope(NodeWithEnvelope indexNode) {
 		setIndexNodeEnvelope(indexNode.node, indexNode.envelope);
 	}
 


### PR DESCRIPTION
This PR introduces a `readOnly` flag throughout the layering and indexing APIs, updates all callers to propagate it, and enforces write protection on layers and indexes.  
- Added `readOnly` parameter to `LayerIndexReader.init`, `RTreeIndex.init`, `Layer.initialize`, and related factory methods.  
- Enforced write checks via `checkWritable()` in `EditableLayerImpl`, `RTreeIndex`, `DynamicLayer`, and others.  
- Updated all calls to `getLayer`/`getOrCreateLayer` in main code and tests to supply the appropriate `readOnly` boolean.