### PR TITLE
Remove unnecessary `Constants` interface implementation and use static imports for spatial constants

### DIFF
--- a/osm-server-plugin/src/main/java/org/neo4j/spatial/osm/server/plugin/OSMGeometryEncoder.java
+++ b/osm-server-plugin/src/main/java/org/neo4j/spatial/osm/server/plugin/OSMGeometryEncoder.java
@@ -19,6 +19,13 @@
  */
 package org.neo4j.spatial.osm.server.plugin;
 
+import static org.neo4j.gis.spatial.Constants.GTYPE_LINESTRING;
+import static org.neo4j.gis.spatial.Constants.GTYPE_MULTILINESTRING;
+import static org.neo4j.gis.spatial.Constants.GTYPE_MULTIPOINT;
+import static org.neo4j.gis.spatial.Constants.GTYPE_MULTIPOLYGON;
+import static org.neo4j.gis.spatial.Constants.GTYPE_POINT;
+import static org.neo4j.gis.spatial.Constants.GTYPE_POLYGON;
+import static org.neo4j.gis.spatial.Constants.PROP_TYPE;
 import static org.neo4j.gis.spatial.utilities.TraverserFactory.createTraverserInBackwardsCompatibleWay;
 
 import java.io.Serial;

--- a/osm-server-plugin/src/main/java/org/neo4j/spatial/osm/server/plugin/OSMImporter.java
+++ b/osm-server-plugin/src/main/java/org/neo4j/spatial/osm/server/plugin/OSMImporter.java
@@ -20,6 +20,13 @@
 package org.neo4j.spatial.osm.server.plugin;
 
 import static java.util.Arrays.asList;
+import static org.neo4j.gis.spatial.Constants.GTYPE_GEOMETRY;
+import static org.neo4j.gis.spatial.Constants.GTYPE_LINESTRING;
+import static org.neo4j.gis.spatial.Constants.GTYPE_MULTILINESTRING;
+import static org.neo4j.gis.spatial.Constants.GTYPE_MULTIPOINT;
+import static org.neo4j.gis.spatial.Constants.GTYPE_POINT;
+import static org.neo4j.gis.spatial.Constants.GTYPE_POLYGON;
+import static org.neo4j.gis.spatial.Constants.PROP_TYPE;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -51,7 +58,6 @@ import javax.xml.stream.XMLStreamReader;
 import org.geotools.referencing.datum.DefaultEllipsoid;
 import org.neo4j.dbms.api.DatabaseManagementService;
 import org.neo4j.dbms.api.DatabaseManagementServiceBuilder;
-import org.neo4j.gis.spatial.Constants;
 import org.neo4j.gis.spatial.SpatialDatabaseService;
 import org.neo4j.gis.spatial.index.IndexManagerImpl;
 import org.neo4j.gis.spatial.rtree.NullListener;
@@ -76,7 +82,7 @@ import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.spatial.api.Envelope;
 import org.neo4j.spatial.api.monitoring.ProgressListener;
 
-public class OSMImporter implements Constants {
+public class OSMImporter {
 
 	private static final Logger LOGGER = Logger.getLogger(OSMImporter.class.getName());
 

--- a/osm-server-plugin/src/test/java/org/neo4j/spatial/osm/server/plugin/TestDynamicLayers.java
+++ b/osm-server-plugin/src/test/java/org/neo4j/spatial/osm/server/plugin/TestDynamicLayers.java
@@ -22,6 +22,11 @@ package org.neo4j.spatial.osm.server.plugin;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.neo4j.configuration.GraphDatabaseSettings.DEFAULT_DATABASE_NAME;
+import static org.neo4j.gis.spatial.Constants.GTYPE_GEOMETRY;
+import static org.neo4j.gis.spatial.Constants.GTYPE_LINESTRING;
+import static org.neo4j.gis.spatial.Constants.GTYPE_MULTILINESTRING;
+import static org.neo4j.gis.spatial.Constants.GTYPE_POINT;
+import static org.neo4j.gis.spatial.Constants.GTYPE_POLYGON;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -34,7 +39,6 @@ import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.Polygon;
-import org.neo4j.gis.spatial.Constants;
 import org.neo4j.gis.spatial.DynamicLayer;
 import org.neo4j.gis.spatial.ShapefileImporter;
 import org.neo4j.gis.spatial.SpatialDatabaseService;
@@ -53,7 +57,7 @@ import org.neo4j.spatial.geotools.plugin.Neo4jSpatialDataStore;
 import org.neo4j.spatial.osm.server.plugin.procedures.OsmSpatialProcedures;
 import org.neo4j.spatial.testutils.Neo4jTestCase;
 
-public class TestDynamicLayers extends Neo4jTestCase implements Constants {
+public class TestDynamicLayers extends Neo4jTestCase {
 
 	@Override
 	protected List<Class<?>> loadProceduresAndFunctions() {

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/AbstractGeometryEncoder.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/AbstractGeometryEncoder.java
@@ -19,6 +19,15 @@
  */
 package org.neo4j.gis.spatial;
 
+import static org.neo4j.gis.spatial.Constants.GTYPE_LINESTRING;
+import static org.neo4j.gis.spatial.Constants.GTYPE_MULTILINESTRING;
+import static org.neo4j.gis.spatial.Constants.GTYPE_MULTIPOINT;
+import static org.neo4j.gis.spatial.Constants.GTYPE_MULTIPOLYGON;
+import static org.neo4j.gis.spatial.Constants.GTYPE_POINT;
+import static org.neo4j.gis.spatial.Constants.GTYPE_POLYGON;
+import static org.neo4j.gis.spatial.Constants.PROP_BBOX;
+import static org.neo4j.gis.spatial.Constants.PROP_TYPE;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -32,7 +41,7 @@ import org.neo4j.spatial.api.Envelope;
 import org.neo4j.spatial.api.encoder.GeometryEncoder;
 import org.neo4j.spatial.api.layer.Layer;
 
-public abstract class AbstractGeometryEncoder implements GeometryEncoder, Constants {
+public abstract class AbstractGeometryEncoder implements GeometryEncoder {
 
 	protected String bboxProperty = PROP_BBOX;
 

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/ShapefileImporter.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/ShapefileImporter.java
@@ -55,7 +55,7 @@ import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.spatial.api.layer.Layer;
 import org.neo4j.spatial.api.monitoring.ProgressListener;
 
-public class ShapefileImporter implements Constants {
+public class ShapefileImporter {
 
 	private static final Logger LOGGER = Logger.getLogger(ShapefileImporter.class.getName());
 	private final int commitInterval;

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/SpatialDatabaseService.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/SpatialDatabaseService.java
@@ -19,6 +19,18 @@
  */
 package org.neo4j.gis.spatial;
 
+import static org.neo4j.gis.spatial.Constants.GTYPE_GEOMETRY;
+import static org.neo4j.gis.spatial.Constants.GTYPE_LINESTRING;
+import static org.neo4j.gis.spatial.Constants.GTYPE_MULTILINESTRING;
+import static org.neo4j.gis.spatial.Constants.GTYPE_MULTIPOINT;
+import static org.neo4j.gis.spatial.Constants.GTYPE_MULTIPOLYGON;
+import static org.neo4j.gis.spatial.Constants.GTYPE_POINT;
+import static org.neo4j.gis.spatial.Constants.GTYPE_POLYGON;
+import static org.neo4j.gis.spatial.Constants.LABEL_LAYER;
+import static org.neo4j.gis.spatial.Constants.PROP_LAYER;
+import static org.neo4j.gis.spatial.Constants.PROP_LAYER_CLASS;
+import static org.neo4j.gis.spatial.Constants.PROP_LAYER_TYPE;
+
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -59,7 +71,7 @@ import org.neo4j.spatial.api.monitoring.ProgressListener;
  * depending on the actual data model backing the GIS. All real data access is then done
  * through the layer instance which interprets the GIS functions in terms of the underlying model.
  */
-public class SpatialDatabaseService implements Constants {
+public class SpatialDatabaseService {
 
 	public final IndexManager indexManager;
 
@@ -448,6 +460,7 @@ public class SpatialDatabaseService implements Constants {
 	public Layer getOrCreateRegisteredTypeLayer(Transaction tx, String name, RegisteredLayerType registeredLayerType,
 			String encoderConfig, String indexConfig, boolean readOnly) {
 		return getOrCreateLayer(tx, name, registeredLayerType.geometryEncoder(), registeredLayerType.layerClass(),
-				(encoderConfig == null) ? registeredLayerType.defaultEncoderConfig() : encoderConfig, indexConfig, readOnly);
+				(encoderConfig == null) ? registeredLayerType.defaultEncoderConfig() : encoderConfig, indexConfig,
+				readOnly);
 	}
 }

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/encoders/AbstractSinglePropertyEncoder.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/encoders/AbstractSinglePropertyEncoder.java
@@ -20,6 +20,9 @@
 
 package org.neo4j.gis.spatial.encoders;
 
+import static org.neo4j.gis.spatial.Constants.PROP_GEOM;
+import static org.neo4j.gis.spatial.Constants.PROP_TYPE;
+
 import java.util.Set;
 import org.neo4j.gis.spatial.AbstractGeometryEncoder;
 

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/encoders/NativePointEncoder.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/encoders/NativePointEncoder.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.gis.spatial.encoders;
 
+import static org.neo4j.gis.spatial.Constants.GTYPE_POINT;
+import static org.neo4j.gis.spatial.Constants.PROP_TYPE;
+
 import java.util.List;
 import java.util.Set;
 import org.locationtech.jts.geom.Coordinate;

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/encoders/NativePointsEncoder.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/encoders/NativePointsEncoder.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.gis.spatial.encoders;
 
+import static org.neo4j.gis.spatial.Constants.PROP_TYPE;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/encoders/SimpleGraphEncoder.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/encoders/SimpleGraphEncoder.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.gis.spatial.encoders;
 
+import static org.neo4j.gis.spatial.Constants.GTYPE_LINESTRING;
+import static org.neo4j.gis.spatial.Constants.PROP_TYPE;
+
 import java.util.List;
 import java.util.Set;
 import org.locationtech.jts.geom.Coordinate;

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/encoders/SimplePointEncoder.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/encoders/SimplePointEncoder.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.gis.spatial.encoders;
 
+import static org.neo4j.gis.spatial.Constants.PROP_TYPE;
+
 import java.util.List;
 import java.util.Set;
 import org.locationtech.jts.geom.Coordinate;

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/encoders/SimplePropertyEncoder.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/encoders/SimplePropertyEncoder.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.gis.spatial.encoders;
 
+import static org.neo4j.gis.spatial.Constants.PROP_TYPE;
+
 import java.util.List;
 import java.util.Set;
 import org.locationtech.jts.geom.Coordinate;

--- a/server-plugin/src/main/java/org/neo4j/gis/spatial/procedures/SpatialProcedures.java
+++ b/server-plugin/src/main/java/org/neo4j/gis/spatial/procedures/SpatialProcedures.java
@@ -29,9 +29,9 @@ import static org.neo4j.gis.spatial.Constants.DOC_JTS_GEOMETRY;
 import static org.neo4j.gis.spatial.Constants.DOC_LAYER_NAME;
 import static org.neo4j.gis.spatial.Constants.DOC_LAYER_TYPE;
 import static org.neo4j.gis.spatial.Constants.DOC_URI;
+import static org.neo4j.gis.spatial.Constants.INDEX_TYPE_RTREE;
 import static org.neo4j.gis.spatial.Constants.PROP_CRS;
 import static org.neo4j.gis.spatial.Constants.WGS84_CRS_NAME;
-import static org.neo4j.gis.spatial.SpatialDatabaseService.INDEX_TYPE_RTREE;
 import static org.neo4j.procedure.Mode.READ;
 import static org.neo4j.procedure.Mode.WRITE;
 

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/LayerSignatureTest.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/LayerSignatureTest.java
@@ -34,7 +34,7 @@ import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.spatial.api.layer.Layer;
 import org.neo4j.spatial.testutils.Neo4jTestCase;
 
-public class LayerSignatureTest extends Neo4jTestCase implements Constants {
+public class LayerSignatureTest extends Neo4jTestCase {
 
 	private SpatialDatabaseService spatial;
 

--- a/server-plugin/src/test/java/org/neo4j/gis/spatial/procedures/SpatialProceduresTest.java
+++ b/server-plugin/src/test/java/org/neo4j/gis/spatial/procedures/SpatialProceduresTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.neo4j.gis.spatial.Constants.INDEX_TYPE_RTREE;
 import static org.neo4j.gis.spatial.Constants.LABEL_LAYER;
 import static org.neo4j.gis.spatial.Constants.PROP_GEOMENCODER;
 import static org.neo4j.gis.spatial.Constants.PROP_GEOMENCODER_CONFIG;
@@ -133,9 +134,9 @@ public class SpatialProceduresTest extends AbstractApiTest {
 	private static Layer makeLayerOfVariousTypes(SpatialDatabaseService spatial, Transaction tx, String name,
 			int index) {
 		return switch (index % 3) {
-			case 0 -> spatial.getOrCreateSimplePointLayer(tx, name, SpatialDatabaseService.INDEX_TYPE_RTREE, "x", "y",
+			case 0 -> spatial.getOrCreateSimplePointLayer(tx, name, INDEX_TYPE_RTREE, "x", "y",
 					null, false);
-			case 1 -> spatial.getOrCreateNativePointLayer(tx, name, SpatialDatabaseService.INDEX_TYPE_RTREE, "location",
+			case 1 -> spatial.getOrCreateNativePointLayer(tx, name, INDEX_TYPE_RTREE, "location",
 					null, false);
 			default -> spatial.getOrCreateDefaultLayer(tx, name, null, false);
 		};


### PR DESCRIPTION
This PR refactors the codebase to eliminate the anti-pattern of implementing the `Constants` interface solely to access constant values. Instead, it uses explicit static imports for the specific constants needed in each class.

- Removes `implements Constants` from 7 classes across the codebase
- Adds explicit static imports for spatial constants (GTYPE_*, PROP_*, INDEX_TYPE_RTREE, etc.) where needed
- Corrects the import source for `INDEX_TYPE_RTREE` from `SpatialDatabaseService` to `Constants` where it's actually defined
